### PR TITLE
Remove v2 endpoint for session init

### DIFF
--- a/src/Common/OmnichannelEndpoints.ts
+++ b/src/Common/OmnichannelEndpoints.ts
@@ -2,7 +2,6 @@ export default class OmnichannelEndpoints {
   public static readonly LiveChatConfigPath = "livechatconnector/config";
   public static readonly LiveChatSessionInitPath = "livechatconnector/sessioninit";
   public static readonly LiveChatAuthSessionInitPath = "livechatconnector/auth/sessioninit";
-  public static readonly LiveChatv2SessionInitPath = "livechatconnector/v2/sessioninit";
   public static readonly LiveChatGetChatTokenPath = "livechatconnector/getchattoken";
   public static readonly LiveChatv2GetChatTokenPath = "livechatconnector/v2/getchattoken";
   public static readonly LiveChatAuthGetChatTokenPath = "livechatconnector/auth/getchattoken";

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -405,9 +405,6 @@ export default class SDK implements ISDK {
     const headers: StringMap = Constants.defaultHeaders;
     let endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.LiveChatSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
 
-    if (this.liveChatVersion === LiveChatVersion.V2) {
-      endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.LiveChatv2SessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
-    }
     if (authenticatedUserToken) {
       endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
       headers[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;


### PR DESCRIPTION
The sessioninit logic is not going to change internally. So we are removing this endpoint.