### PR TITLE
Users/aidhage/typingindicatorbug

### DIFF
--- a/src/Interfaces/ISDK.ts
+++ b/src/Interfaces/ISDK.ts
@@ -16,5 +16,5 @@ export default interface ISDK {
   emailTranscript(requestId: string, token: string, emailRequestBody: object): Promise<void>;
   fetchDataMaskingInfo(requestId: string): Promise<IDataMaskingInfo>;
   makeSecondaryChannelEventRequest(requestId: string, secondaryChannelEventRequestBody: object): Promise<void>;
-  sendTypingIndicator(requestId: string): Promise<void>;
+  sendTypingIndicator(requestId: string, currentLiveChatVersion: number): Promise<void>;
 }

--- a/src/Interfaces/ISendTypingIndicatorOptionalParams.ts
+++ b/src/Interfaces/ISendTypingIndicatorOptionalParams.ts
@@ -1,0 +1,3 @@
+export default interface ISecondaryChannelEventOptionalParams {
+    currentLiveChatVersion?: number;
+}

--- a/src/Interfaces/ISendTypingIndicatorOptionalParams.ts
+++ b/src/Interfaces/ISendTypingIndicatorOptionalParams.ts
@@ -1,3 +1,0 @@
-export default interface ISecondaryChannelEventOptionalParams {
-    currentLiveChatVersion?: number;
-}

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -16,7 +16,6 @@ import IReconnectableChatsParams from "./Interfaces/IReconnectableChatsParams";
 import ISDK from "./Interfaces/ISDK";
 import ISDKConfiguration from "./Interfaces/ISDKConfiguration";
 import ISecondaryChannelEventOptionalParams from "./Interfaces/ISecondaryChannelEventOptionalParams";
-import ISendTypingIndicatorOptionalParams from "./Interfaces/ISendTypingIndicatorOptionalParams";
 import ISessionCloseOptionalParams from "./Interfaces/ISessionCloseOptionalParams";
 import ISessionInitOptionalParams from "./Interfaces/ISessionInitOptionalParams";
 import ISubmitPostChatResponseOptionalParams from "./Interfaces/ISubmitPostChatResponseOptionalParams";
@@ -967,10 +966,9 @@ export default class SDK implements ISDK {
   /** Send typing indicator
    * @param requestId RequestId of the omnichannel session.
    */
-  public async sendTypingIndicator(requestId: string, sendTypingIndicatorOptionalParams: ISendTypingIndicatorOptionalParams = {}): Promise<void> {   
+  public async sendTypingIndicator(requestId: string, currentLiveChatVersion: number): Promise<void> {   
     // avoiding logging Info for typingindicator to reduce log traffic
     const timer = Timer.TIMER();
-    const { currentLiveChatVersion } = sendTypingIndicatorOptionalParams;
     if (!currentLiveChatVersion || currentLiveChatVersion !== LiveChatVersion.V2) { throw new Error('Typing indicator is only supported on v2') }
     const endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.SendTypingIndicatorPath}/${requestId}`;
     const axiosInstance = axios.create();

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -16,6 +16,7 @@ import IReconnectableChatsParams from "./Interfaces/IReconnectableChatsParams";
 import ISDK from "./Interfaces/ISDK";
 import ISDKConfiguration from "./Interfaces/ISDKConfiguration";
 import ISecondaryChannelEventOptionalParams from "./Interfaces/ISecondaryChannelEventOptionalParams";
+import ISendTypingIndicatorOptionalParams from "./Interfaces/ISendTypingIndicatorOptionalParams";
 import ISessionCloseOptionalParams from "./Interfaces/ISessionCloseOptionalParams";
 import ISessionInitOptionalParams from "./Interfaces/ISessionInitOptionalParams";
 import ISubmitPostChatResponseOptionalParams from "./Interfaces/ISubmitPostChatResponseOptionalParams";
@@ -970,7 +971,7 @@ export default class SDK implements ISDK {
     // avoiding logging Info for typingindicator to reduce log traffic
     const timer = Timer.TIMER();
     const { currentLiveChatVersion } = sendTypingIndicatorOptionalParams;
-    if (this.liveChatVersion !== LiveChatVersion.V2 || (currentLiveChatVersion && currentLiveChatVersion !== LiveChatVersion.V2)) { throw new Error('Only supported on v2') }
+    if (!currentLiveChatVersion && currentLiveChatVersion !== LiveChatVersion.V2) { throw new Error('Typing indicator is only supported on v2') }
     const endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.SendTypingIndicatorPath}/${requestId}`;
     const axiosInstance = axios.create();
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -971,7 +971,7 @@ export default class SDK implements ISDK {
     // avoiding logging Info for typingindicator to reduce log traffic
     const timer = Timer.TIMER();
     const { currentLiveChatVersion } = sendTypingIndicatorOptionalParams;
-    if (!currentLiveChatVersion && currentLiveChatVersion !== LiveChatVersion.V2) { throw new Error('Typing indicator is only supported on v2') }
+    if (!currentLiveChatVersion || currentLiveChatVersion !== LiveChatVersion.V2) { throw new Error('Typing indicator is only supported on v2') }
     const endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.SendTypingIndicatorPath}/${requestId}`;
     const axiosInstance = axios.create();
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -966,10 +966,11 @@ export default class SDK implements ISDK {
   /** Send typing indicator
    * @param requestId RequestId of the omnichannel session.
    */
-  public async sendTypingIndicator(requestId: string): Promise<void> {
-    if (this.liveChatVersion !== LiveChatVersion.V2) { throw new Error('Only supported on v2') }
+  public async sendTypingIndicator(requestId: string, sendTypingIndicatorOptionalParams: ISendTypingIndicatorOptionalParams = {}): Promise<void> {   
     // avoiding logging Info for typingindicator to reduce log traffic
     const timer = Timer.TIMER();
+    const { currentLiveChatVersion } = sendTypingIndicatorOptionalParams;
+    if (this.liveChatVersion !== LiveChatVersion.V2 || (currentLiveChatVersion && currentLiveChatVersion !== LiveChatVersion.V2)) { throw new Error('Only supported on v2') }
     const endpoint = `${this.omnichannelConfiguration.orgUrl}/${OmnichannelEndpoints.SendTypingIndicatorPath}/${requestId}`;
     const axiosInstance = axios.create();
 

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -15,7 +15,6 @@ import IOmnichannelConfiguration from "../src/Interfaces/IOmnichannelConfigurati
 import IReconnectableChatsParams from "../src/Interfaces/IReconnectableChatsParams";
 import ISDKConfiguration from "../src/Interfaces/ISDKConfiguration";
 import ISecondaryChannelEventOptionalParams from "../src/Interfaces/ISecondaryChannelEventOptionalParams";
-import ISendTypingIndicatorOptionalParams from "../src/Interfaces/ISendTypingIndicatorOptionalParams";
 import ISessionCloseOptionalParams from "../src/Interfaces/ISessionCloseOptionalParams";
 import ISessionInitOptionalParams from "../src/Interfaces/ISessionInitOptionalParams";
 import ISubmitPostChatResponseOptionalParams from "../src/Interfaces/ISubmitPostChatResponseOptionalParams";
@@ -550,15 +549,12 @@ describe("SDK unit tests", () => {
         });
     });
     describe("Test sendtypingindicator method", () => {
-
-        const sendTypingIndicatorOptionalParams = {
-            currentLiveChatVersion: 2
-        };
         
         it("Should return promise resolve", (done) => {
+            let currentLiveChatVersion = 2;
             spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
-            const result = sdk.sendTypingIndicator(requestId, sendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
+            const result = sdk.sendTypingIndicator(requestId, currentLiveChatVersion);
             result.then(() => {
                 expect(axiosInstMock).toHaveBeenCalled();
                 done();
@@ -566,10 +562,11 @@ describe("SDK unit tests", () => {
         });
 
         it("Should reject when axiosInstance throws an error", (done) => {
+            let currentLiveChatVersion = 2;
             spyOn<any>(axios, "create").and.returnValue(axiosInstMockWithError);
             spyOn(ocsdkLogger, "log").and.callFake(() => { });
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
-            const result = sdk.sendTypingIndicator(requestId, sendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
+            const result = sdk.sendTypingIndicator(requestId, currentLiveChatVersion);
             result.then(() => {}, () => {
                 expect(ocsdkLogger.log).toHaveBeenCalled();
                 done();
@@ -577,15 +574,13 @@ describe("SDK unit tests", () => {
         });
         
         it("Should throw error when currentlivechatversion is 1", (done) => {
+            let currentLiveChatVersion = 1;
             spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
             spyOn(ocsdkLogger, "log").and.callFake(() => { });
-            const mocksendTypingIndicatorOptionalParams = {
-                currentLiveChatVersion: 1
-            };           
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
-            const result = sdk.sendTypingIndicator(requestId, mocksendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
-            result.then(() => {}, () => {
-                expect(ocsdkLogger.log).toHaveBeenCalled();
+            const result = sdk.sendTypingIndicator(requestId, currentLiveChatVersion);
+            result.then(() => {}, (error) => {
+                expect(error).toEqual(new Error('Typing indicator is only supported on v2'));
                 done();
             });
         });

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -15,6 +15,7 @@ import IOmnichannelConfiguration from "../src/Interfaces/IOmnichannelConfigurati
 import IReconnectableChatsParams from "../src/Interfaces/IReconnectableChatsParams";
 import ISDKConfiguration from "../src/Interfaces/ISDKConfiguration";
 import ISecondaryChannelEventOptionalParams from "../src/Interfaces/ISecondaryChannelEventOptionalParams";
+import ISendTypingIndicatorOptionalParams from "../src/Interfaces/ISendTypingIndicatorOptionalParams";
 import ISessionCloseOptionalParams from "../src/Interfaces/ISessionCloseOptionalParams";
 import ISessionInitOptionalParams from "../src/Interfaces/ISessionInitOptionalParams";
 import ISubmitPostChatResponseOptionalParams from "../src/Interfaces/ISubmitPostChatResponseOptionalParams";
@@ -550,11 +551,14 @@ describe("SDK unit tests", () => {
     });
     describe("Test sendtypingindicator method", () => {
 
+        const sendTypingIndicatorOptionalParams = {
+            currentLiveChatVersion: 2
+        };
+        
         it("Should return promise resolve", (done) => {
             spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
-            sdk.liveChatVersion = LiveChatVersion.V2
-            const result = sdk.sendTypingIndicator(requestId);
+            const result = sdk.sendTypingIndicator(requestId, sendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
             result.then(() => {
                 expect(axiosInstMock).toHaveBeenCalled();
                 done();
@@ -565,8 +569,21 @@ describe("SDK unit tests", () => {
             spyOn<any>(axios, "create").and.returnValue(axiosInstMockWithError);
             spyOn(ocsdkLogger, "log").and.callFake(() => { });
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
-            sdk.liveChatVersion = LiveChatVersion.V2
-            const result = sdk.sendTypingIndicator(requestId);
+            const result = sdk.sendTypingIndicator(requestId, sendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
+            result.then(() => {}, () => {
+                expect(ocsdkLogger.log).toHaveBeenCalled();
+                done();
+            });
+        });
+        
+        it("Should throw error when currentlivechatversion is 1", (done) => {
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
+            spyOn(ocsdkLogger, "log").and.callFake(() => { });
+            const mocksendTypingIndicatorOptionalParams = {
+                currentLiveChatVersion: 1
+            };           
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
+            const result = sdk.sendTypingIndicator(requestId, mocksendTypingIndicatorOptionalParams as ISendTypingIndicatorOptionalParams);
             result.then(() => {}, () => {
                 expect(ocsdkLogger.log).toHaveBeenCalled();
                 done();


### PR DESCRIPTION
Bug - Issue 2239891: [ACS][LiveChat]Typing indicator error in console on LCW when hard refresh the page
Adding livechatversion argument in sendtypingindicator().
Tested in ocacsdev int env. LCW link - https://octestoccobranamgs.blob.core.windows.net/aidhagedev/ocspamtypingindicator.html