### PR TITLE
adding use case validation for out of office hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `livechatconnector/v3/getchattoken` endpoint
 - `livechatconnector/v3/auth/getchattoken` endpoint
+- Stop retry when the error is related to out of office hours.
 
 ## [0.3.3] - 2023-01-09
 ### Fix

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -13,7 +13,9 @@ export default class Constants {
   public static readonly defaultLocale = "en-us";
   public static readonly noContentStatusCode = 204;
   public static readonly tooManyRequestsStatusCode = 429;
-  public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
+  public static readonly outOfOfficeErrorCode = 705;
+  
+public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
   public static readonly transactionid = "transaction-id";
   public static readonly customerDisplayName = "customerDisplayName";
   public static readonly hiddenContentPlaceholder = "*content hidden*";

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -13,7 +13,7 @@ export default class Constants {
   public static readonly defaultLocale = "en-us";
   public static readonly noContentStatusCode = 204;
   public static readonly tooManyRequestsStatusCode = 429;
-  public static readonly badRequest = 429;
+  public static readonly badRequestStatusCode = 400;
   public static readonly outOfOfficeErrorCode = 705;
   public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
   public static readonly transactionid = "transaction-id";

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -14,8 +14,7 @@ export default class Constants {
   public static readonly noContentStatusCode = 204;
   public static readonly tooManyRequestsStatusCode = 429;
   public static readonly outOfOfficeErrorCode = 705;
-  
-public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
+  public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
   public static readonly transactionid = "transaction-id";
   public static readonly customerDisplayName = "customerDisplayName";
   public static readonly hiddenContentPlaceholder = "*content hidden*";

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -13,6 +13,7 @@ export default class Constants {
   public static readonly defaultLocale = "en-us";
   public static readonly noContentStatusCode = 204;
   public static readonly tooManyRequestsStatusCode = 429;
+  public static readonly badRequest = 429;
   public static readonly outOfOfficeErrorCode = 705;
   public static readonly sensitiveProperties = ["AuthenticatedUserToken"];
   public static readonly transactionid = "transaction-id";

--- a/src/Interfaces/IAxiosRetryOptions.ts
+++ b/src/Interfaces/IAxiosRetryOptions.ts
@@ -1,3 +1,4 @@
+
 export default interface IAxiosRetryOptions {
   /**
    * Number of retries before failing.
@@ -7,4 +8,11 @@ export default interface IAxiosRetryOptions {
    * Whether to retry on 429 HTTP status code response
    */
   retryOn429?: boolean | true;
+
+  /**
+   * 
+   * Function to handle logic and evaluate if retry should continue based on response results.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  shouldRetry? (response? : any, axiosRetryOptions?: IAxiosRetryOptions)  : boolean
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -42,7 +42,7 @@ import * as hash from "crypto";
 import { CustomContextData } from "./Utils/CustomContextData";
 import { RequestTimeoutConfig } from "./Common/RequestTimeoutConfig";
 import throwClientHTTPTimeoutError from "./Utils/throwClientHTTPError";
-import initSessionRetryHandler from "./Utils/InitSessionRetryHandler";
+import sessionInitRetryHandler from "./Utils/InitSessionRetryHandler";
 
 export default class SDK implements ISDK {
   private static defaultRequestTimeoutConfig: RequestTimeoutConfig = {
@@ -520,7 +520,7 @@ export default class SDK implements ISDK {
 
     axiosRetry(axiosInstance, {
       retries: this.configuration.maxRequestRetriesOnFailure,
-      shouldRetry: initSessionRetryHandler
+      shouldRetry: sessionInitRetryHandler
     });
 
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -42,6 +42,7 @@ import * as hash from "crypto";
 import { CustomContextData } from "./Utils/CustomContextData";
 import { RequestTimeoutConfig } from "./Common/RequestTimeoutConfig";
 import throwClientHTTPTimeoutError from "./Utils/throwClientHTTPError";
+import initSessionRetryHandler from "./Utils/InitSessionRetryHandler";
 
 export default class SDK implements ISDK {
   private static defaultRequestTimeoutConfig: RequestTimeoutConfig = {
@@ -518,7 +519,10 @@ export default class SDK implements ISDK {
 
 
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { 
+      retries: this.configuration.maxRequestRetriesOnFailure,  
+      shouldRetry : initSessionRetryHandler
+    });
 
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -42,7 +42,7 @@ import * as hash from "crypto";
 import { CustomContextData } from "./Utils/CustomContextData";
 import { RequestTimeoutConfig } from "./Common/RequestTimeoutConfig";
 import throwClientHTTPTimeoutError from "./Utils/throwClientHTTPError";
-import sessionInitRetryHandler from "./Utils/InitSessionRetryHandler";
+import sessionInitRetryHandler from "./Utils/SessionInitRetryHandler";
 
 export default class SDK implements ISDK {
   private static defaultRequestTimeoutConfig: RequestTimeoutConfig = {

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -234,7 +234,7 @@ export default class SDK implements ISDK {
 
     const headers: StringMap = Constants.defaultHeaders;
 
-    const endpoint = createGetChatTokenEndpoint(currentLiveChatVersion as LiveChatVersion || this.liveChatVersion, authenticatedUserToken? true: false);
+    const endpoint = createGetChatTokenEndpoint(currentLiveChatVersion as LiveChatVersion || this.liveChatVersion, authenticatedUserToken ? true : false);
 
     if (authenticatedUserToken) {
       headers[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
@@ -516,65 +516,30 @@ export default class SDK implements ISDK {
   public async sessionInit(requestId: string, sessionInitOptionalParams: ISessionInitOptionalParams = {}): Promise<void> {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSTARTED, "Session Init Started", requestId);
-
-    console.log("E  ZANAYA : sessionInnit : 1");
-
     const axiosInstance = axios.create();
-
-    console.log("ELOPEZANAYA : sessionInnit : 2");
-
-    axiosRetry(axiosInstance, { 
-      retries: this.configuration.maxRequestRetriesOnFailure,  
-      shouldRetry : initSessionRetryHandler
+    axiosRetry(axiosInstance, {
+      retries: this.configuration.maxRequestRetriesOnFailure,
+      shouldRetry: initSessionRetryHandler
     });
-
-    console.log("ELOPEZANAYA : sessionInnit : 3");
-
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;
-
-    console.log("ELOPEZANAYA : sessionInnit : 4");
-
-
     const headers: StringMap = Constants.defaultHeaders;
     let requestPath = `/${OmnichannelEndpoints.LiveChatSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
-
-    console.log("ELOPEZANAYA : sessionInnit : 5");
-
-
     if (authenticatedUserToken) {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
       headers[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     }
 
-    console.log("ELOPEZANAYA : sessionInnit : 6");
-
-
     if (reconnectId) {
       requestPath += `/${reconnectId}`;
     }
 
-    console.log("ELOPEZANAYA : sessionInnit : 7");
-
-
     const queryParams = `channelId=${this.omnichannelConfiguration.channelId}`;
     requestPath += `?${queryParams}`;
-
-    console.log("ELOPEZANAYA : sessionInnit : 8");
-
-
     const data: InitContext = initContext || {};
-
-    console.log("ELOPEZANAYA : sessionInnit : 9");
-
 
     if (getContext && !window.document) {
       return Promise.reject(new Error(`getContext is only supported on web browsers`));
     }
-
-
-    console.log("ELOPEZANAYA : sessionInnit : 10");
-
-
     if (getContext) {
       data.browser = BrowserInfo.getBrowserName();
       data.device = DeviceInfo.getDeviceType();
@@ -582,26 +547,15 @@ export default class SDK implements ISDK {
       data.os = OSInfo.getOsType();
     }
 
-    console.log("ELOPEZANAYA : sessionInnit : 11");
-
-
     // Set default locale if locale is empty
     if (!data.locale) {
       data.locale = Constants.defaultLocale;
     }
 
-    console.log("ELOPEZANAYA : sessionInnit : 12");
-
-
     // Validate locale
     if (data.locale && !Locales.supportedLocales.includes(data.locale)) {
-      console.log("ELOPEZANAYA : sessionInnit : reject due to no locale");
-
       return Promise.reject(new Error(`Unsupported locale: '${data.locale}'`));
     }
-
-    console.log("ELOPEZANAYA : sessionInnit : 13");
-
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -613,38 +567,26 @@ export default class SDK implements ISDK {
       timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.sessionInit
     };
 
-    console.log("ELOPEZANAYA : sessionInnit : 14");
-
-
     try {
 
-      console.log("ELOPEZANAYA : sessionInnit : before calling axios");
       const response = await axiosInstance(options);
-      console.log("ELOPEZANAYA : sessionInnit : after calling axios");
 
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data);
-      console.log("ELOPEZANAYA : sessionInnit : 15");
 
     } catch (error) {
 
-      console.log("ELOPEZANAYA : sessionInnit : 16 =>  error => " + JSON.stringify(error));
 
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
 
-      console.log("ELOPEZANAYA : sessionInnit : 17");
 
       this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONINITFAILED, "Session Init failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data);
-      
-      console.log("ELOPEZANAYA : sessionInnit : 18");
 
 
       if (error.code === Constants.axiosTimeoutErrorCode) {
-        console.log("ELOPEZANAYA throwing error : TIMEOUT  ");
 
         throwClientHTTPTimeoutError();
       }
-      console.log("ELOPEZANAYA throwing error : e => " + JSON.stringify(error));
       throw error;
     }
   }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -517,35 +517,63 @@ export default class SDK implements ISDK {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSTARTED, "Session Init Started", requestId);
 
+    console.log("E  ZANAYA : sessionInnit : 1");
 
     const axiosInstance = axios.create();
+
+    console.log("ELOPEZANAYA : sessionInnit : 2");
+
     axiosRetry(axiosInstance, { 
       retries: this.configuration.maxRequestRetriesOnFailure,  
       shouldRetry : initSessionRetryHandler
     });
 
+    console.log("ELOPEZANAYA : sessionInnit : 3");
+
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;
+
+    console.log("ELOPEZANAYA : sessionInnit : 4");
+
 
     const headers: StringMap = Constants.defaultHeaders;
     let requestPath = `/${OmnichannelEndpoints.LiveChatSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
+
+    console.log("ELOPEZANAYA : sessionInnit : 5");
+
 
     if (authenticatedUserToken) {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
       headers[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     }
 
+    console.log("ELOPEZANAYA : sessionInnit : 6");
+
+
     if (reconnectId) {
       requestPath += `/${reconnectId}`;
     }
 
+    console.log("ELOPEZANAYA : sessionInnit : 7");
+
+
     const queryParams = `channelId=${this.omnichannelConfiguration.channelId}`;
     requestPath += `?${queryParams}`;
 
+    console.log("ELOPEZANAYA : sessionInnit : 8");
+
+
     const data: InitContext = initContext || {};
+
+    console.log("ELOPEZANAYA : sessionInnit : 9");
+
 
     if (getContext && !window.document) {
       return Promise.reject(new Error(`getContext is only supported on web browsers`));
     }
+
+
+    console.log("ELOPEZANAYA : sessionInnit : 10");
+
 
     if (getContext) {
       data.browser = BrowserInfo.getBrowserName();
@@ -554,15 +582,26 @@ export default class SDK implements ISDK {
       data.os = OSInfo.getOsType();
     }
 
+    console.log("ELOPEZANAYA : sessionInnit : 11");
+
+
     // Set default locale if locale is empty
     if (!data.locale) {
       data.locale = Constants.defaultLocale;
     }
 
+    console.log("ELOPEZANAYA : sessionInnit : 12");
+
+
     // Validate locale
     if (data.locale && !Locales.supportedLocales.includes(data.locale)) {
+      console.log("ELOPEZANAYA : sessionInnit : reject due to no locale");
+
       return Promise.reject(new Error(`Unsupported locale: '${data.locale}'`));
     }
+
+    console.log("ELOPEZANAYA : sessionInnit : 13");
+
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -574,17 +613,38 @@ export default class SDK implements ISDK {
       timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.sessionInit
     };
 
+    console.log("ELOPEZANAYA : sessionInnit : 14");
+
+
     try {
+
+      console.log("ELOPEZANAYA : sessionInnit : before calling axios");
       const response = await axiosInstance(options);
+      console.log("ELOPEZANAYA : sessionInnit : after calling axios");
+
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data);
+      console.log("ELOPEZANAYA : sessionInnit : 15");
 
     } catch (error) {
+
+      console.log("ELOPEZANAYA : sessionInnit : 16 =>  error => " + JSON.stringify(error));
+
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
+
+      console.log("ELOPEZANAYA : sessionInnit : 17");
+
       this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONINITFAILED, "Session Init failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data);
+      
+      console.log("ELOPEZANAYA : sessionInnit : 18");
+
+
       if (error.code === Constants.axiosTimeoutErrorCode) {
+        console.log("ELOPEZANAYA throwing error : TIMEOUT  ");
+
         throwClientHTTPTimeoutError();
       }
+      console.log("ELOPEZANAYA throwing error : e => " + JSON.stringify(error));
       throw error;
     }
   }
@@ -1092,7 +1152,7 @@ export default class SDK implements ISDK {
    * @param error Error
    * @param data Data
    */
-  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any
+  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any    
     if (!this.logger) {
       return;
     }
@@ -1123,6 +1183,7 @@ export default class SDK implements ISDK {
       ExceptionDetails: error,
       RequestPayload: sanitizedRequestPayload
     };
+
     this.logger.log(logLevel, telemetryEventType, customData, description);
   }
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -517,10 +517,12 @@ export default class SDK implements ISDK {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSTARTED, "Session Init Started", requestId);
     const axiosInstance = axios.create();
+
     axiosRetry(axiosInstance, {
       retries: this.configuration.maxRequestRetriesOnFailure,
       shouldRetry: initSessionRetryHandler
     });
+
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;
     const headers: StringMap = Constants.defaultHeaders;
     let requestPath = `/${OmnichannelEndpoints.LiveChatSessionInitPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
@@ -568,23 +570,13 @@ export default class SDK implements ISDK {
     };
 
     try {
-
       const response = await axiosInstance(options);
-
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data);
-
     } catch (error) {
-
-
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-
-
       this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONINITFAILED, "Session Init failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data);
-
-
       if (error.code === Constants.axiosTimeoutErrorCode) {
-
         throwClientHTTPTimeoutError();
       }
       throw error;
@@ -1125,7 +1117,6 @@ export default class SDK implements ISDK {
       ExceptionDetails: error,
       RequestPayload: sanitizedRequestPayload
     };
-
     this.logger.log(logLevel, telemetryEventType, customData, description);
   }
 }

--- a/src/Utils/InitSessionRetryHandler.ts
+++ b/src/Utils/InitSessionRetryHandler.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AxiosResponse } from "axios";
+import Constants from "../Common/Constants";
+import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const initSessionRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
+    if (response && response.status) {
+        switch (response.status) {
+            case Constants.tooManyRequestsStatusCode:
+                if (axiosRetryOptions && axiosRetryOptions.retryOn429 === false) {
+                    return false;
+                }
+                break;
+            case 400:
+                if (parseInt(response.headers.errorcode) === Constants.outOfOfficeErrorCode) {
+                    return false;
+                }
+                break;
+            default: return true;
+        }
+    }
+    return true;
+}
+export default initSessionRetryHandler;

--- a/src/Utils/InitSessionRetryHandler.ts
+++ b/src/Utils/InitSessionRetryHandler.ts
@@ -5,29 +5,21 @@ import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const initSessionRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
-    console.log("ELOPEZANAYA initSessionRetryHandler");
     if (response && response.status) {
-        console.log("ELOPEZANAYA initSessionRetryHandler : status :" + response.status);
         switch (response.status) {
             case Constants.tooManyRequestsStatusCode:
                 if (axiosRetryOptions && axiosRetryOptions.retryOn429 === false) {
-                    console.log("ELOPEZANAYA initSessionRetryHandler : rejecting on 429");
-
                     return false;
                 }
                 break;
             case 400:
                 if (parseInt(response.headers.errorcode) === Constants.outOfOfficeErrorCode) {
-                    console.log("ELOPEZANAYA initSessionRetryHandler : rejecting on 705");
                     return false;
                 }
                 break;
             default: return true;
         }
     }
-    console.log("ELOPEZANAYA initSessionRetryHandler : all good");
-
     return true;
-
 }
 export default initSessionRetryHandler;

--- a/src/Utils/InitSessionRetryHandler.ts
+++ b/src/Utils/InitSessionRetryHandler.ts
@@ -5,21 +5,29 @@ import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const initSessionRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
+    console.log("ELOPEZANAYA initSessionRetryHandler");
     if (response && response.status) {
+        console.log("ELOPEZANAYA initSessionRetryHandler : status :" + response.status);
         switch (response.status) {
             case Constants.tooManyRequestsStatusCode:
                 if (axiosRetryOptions && axiosRetryOptions.retryOn429 === false) {
+                    console.log("ELOPEZANAYA initSessionRetryHandler : rejecting on 429");
+
                     return false;
                 }
                 break;
             case 400:
                 if (parseInt(response.headers.errorcode) === Constants.outOfOfficeErrorCode) {
+                    console.log("ELOPEZANAYA initSessionRetryHandler : rejecting on 705");
                     return false;
                 }
                 break;
             default: return true;
         }
     }
+    console.log("ELOPEZANAYA initSessionRetryHandler : all good");
+
     return true;
+
 }
 export default initSessionRetryHandler;

--- a/src/Utils/LoggingSanitizer.ts
+++ b/src/Utils/LoggingSanitizer.ts
@@ -33,7 +33,7 @@ export class LoggingSanitizer {
     }
   }
 
-  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types   
+  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types     
     if (errorObject && typeof errorObject === 'object' && Object.keys(errorObject)?.length > 0) {
       Object.keys(errorObject)?.forEach((key) => {
         if (Constants.sensitiveProperties.indexOf(key) !== -1) {
@@ -42,20 +42,24 @@ export class LoggingSanitizer {
         }
         if (key === 'data') {
           let data;
+
           if (typeof errorObject[key] === 'string') { // eslint-disable-line security/detect-object-injection
             try {
               data = JSON.parse(errorObject[key]); // eslint-disable-line security/detect-object-injection
             } catch {
               data = undefined;
             }
+          
           }
           if (data) {
             if (Object.keys(data).includes('preChatResponse')) {
               LoggingSanitizer.stripPreChatResponse(data.preChatResponse);
             }
+
             if (Object.keys(data).includes('customContextData')) {
               LoggingSanitizer.stripCustomContextDataValues(data.customContextData);
             }
+
             LoggingSanitizer.stripGeolocation(data);
             errorObject[key] = JSON.stringify(data); // eslint-disable-line security/detect-object-injection
           }

--- a/src/Utils/LoggingSanitizer.ts
+++ b/src/Utils/LoggingSanitizer.ts
@@ -33,42 +33,43 @@ export class LoggingSanitizer {
     }
   }
 
-  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types     
-    if (errorObject && typeof errorObject === 'object' && Object.keys(errorObject)?.length > 0) {
+  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    if(errorObject && typeof errorObject === 'object' && Object.keys(errorObject)?.length > 0) {
       Object.keys(errorObject)?.forEach((key) => {
-        if (Constants.sensitiveProperties.indexOf(key) !== -1) {
-          // remove sensitive properties from error object
-          delete errorObject[`${key}`];
-        }
-        if (key === 'data') {
-          let data;
-
-          if (typeof errorObject[key] === 'string') { // eslint-disable-line security/detect-object-injection
-            try {
-              data = JSON.parse(errorObject[key]); // eslint-disable-line security/detect-object-injection
-            } catch {
-              data = undefined;
-            }
-          
+          if (Constants.sensitiveProperties.indexOf(key) !== -1) {
+            // remove sensitive properties from error object
+            delete errorObject[`${key}`];
           }
-          if (data) {
-            if (Object.keys(data).includes('preChatResponse')) {
-              LoggingSanitizer.stripPreChatResponse(data.preChatResponse);
+
+          if (key === 'data') {
+            let data;
+            if (typeof errorObject[key] === 'string') { // eslint-disable-line security/detect-object-injection
+              try {
+                data = JSON.parse(errorObject[key]); // eslint-disable-line security/detect-object-injection
+              } catch {
+                data = undefined;
+              }
             }
 
-            if (Object.keys(data).includes('customContextData')) {
-              LoggingSanitizer.stripCustomContextDataValues(data.customContextData);
-            }
+            if (data) {
+              if (Object.keys(data).includes('preChatResponse')) {
+                LoggingSanitizer.stripPreChatResponse(data.preChatResponse);
+              }
 
-            LoggingSanitizer.stripGeolocation(data);
-            errorObject[key] = JSON.stringify(data); // eslint-disable-line security/detect-object-injection
+              if (Object.keys(data).includes('customContextData')) {
+                LoggingSanitizer.stripCustomContextDataValues(data.customContextData);
+              }
+
+              LoggingSanitizer.stripGeolocation(data);
+              errorObject[key] = JSON.stringify(data); // eslint-disable-line security/detect-object-injection
+            }
           }
-        }
-        if (errorObject[`${key}`] !== null && typeof errorObject[`${key}`] === 'object') {
-          // check sensitive properties in nested error object
-          this.stripErrorSensitiveProperties(errorObject[`${key}`]);
-          return;
-        }
+
+          if (errorObject[`${key}`] !== null && typeof errorObject[`${key}`] === 'object') {
+            // check sensitive properties in nested error object
+            this.stripErrorSensitiveProperties(errorObject[`${key}`]);
+            return;
+          }
       });
     }
   }

--- a/src/Utils/LoggingSanitizer.ts
+++ b/src/Utils/LoggingSanitizer.ts
@@ -1,69 +1,70 @@
 import Constants from "../Common/Constants";
 
-export class LoggingSanitizer  {
+export class LoggingSanitizer {
   public static stripCustomContextDataValues(customContextData: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    Object.keys(customContextData)?.forEach((contextKey: string) => {
-      if (customContextData[`${contextKey}`]?.value) {
-        customContextData[`${contextKey}`].value = Constants.hiddenContentPlaceholder;
-      }
-    });
+    if (customContextData) {
+      Object.keys(customContextData)?.forEach((contextKey: string) => {
+        if (customContextData[`${contextKey}`]?.value) {
+          customContextData[`${contextKey}`].value = Constants.hiddenContentPlaceholder;
+        }
+      });
+    }
   }
 
   public static stripPreChatResponse(preChatResponse: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    Object.keys(preChatResponse).forEach((responseKey) => {
-      if (preChatResponse[`${responseKey}`] && responseKey !== 'Type') {
-        preChatResponse[`${responseKey}`] = Constants.hiddenContentPlaceholder;
-      }
-    });
+    if (preChatResponse) {
+      Object.keys(preChatResponse).forEach((responseKey) => {
+        if (preChatResponse[`${responseKey}`] && responseKey !== 'Type') {
+          preChatResponse[`${responseKey}`] = Constants.hiddenContentPlaceholder;
+        }
+      });
+    }
   }
 
   public static stripGeolocation(data: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    if (Object.keys(data).includes('longitude')) {
-      data['longitude'] = Constants.hiddenContentPlaceholder;
-    }
+    if (data) {
+      if (Object.keys(data).includes('longitude')) {
+        data['longitude'] = Constants.hiddenContentPlaceholder;
+      }
 
-    if (Object.keys(data).includes('latitude')) {
-      data['latitude'] = Constants.hiddenContentPlaceholder;
+      if (Object.keys(data).includes('latitude')) {
+        data['latitude'] = Constants.hiddenContentPlaceholder;
+      }
     }
   }
 
-  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    if(errorObject && typeof errorObject === 'object' && Object.keys(errorObject)?.length > 0) {
+  public static stripErrorSensitiveProperties(errorObject: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types   
+    if (errorObject && typeof errorObject === 'object' && Object.keys(errorObject)?.length > 0) {
       Object.keys(errorObject)?.forEach((key) => {
-          if (Constants.sensitiveProperties.indexOf(key) !== -1) {
-            // remove sensitive properties from error object
-            delete errorObject[`${key}`];
-          }
-
-          if (key === 'data') {
-            let data;
-            if (typeof errorObject[key] === 'string') { // eslint-disable-line security/detect-object-injection
-              try {
-                data = JSON.parse(errorObject[key]); // eslint-disable-line security/detect-object-injection
-              } catch {
-                data = undefined;
-              }
-            }
-
-            if (data) {
-              if (Object.keys(data).includes('preChatResponse')) {
-                LoggingSanitizer.stripPreChatResponse(data.preChatResponse);
-              }
-
-              if (Object.keys(data).includes('customContextData')) {
-                LoggingSanitizer.stripCustomContextDataValues(data.customContextData);
-              }
-
-              LoggingSanitizer.stripGeolocation(data);
-              errorObject[key] = JSON.stringify(data); // eslint-disable-line security/detect-object-injection
+        if (Constants.sensitiveProperties.indexOf(key) !== -1) {
+          // remove sensitive properties from error object
+          delete errorObject[`${key}`];
+        }
+        if (key === 'data') {
+          let data;
+          if (typeof errorObject[key] === 'string') { // eslint-disable-line security/detect-object-injection
+            try {
+              data = JSON.parse(errorObject[key]); // eslint-disable-line security/detect-object-injection
+            } catch {
+              data = undefined;
             }
           }
-
-          if (errorObject[`${key}`] !== null && typeof errorObject[`${key}`] === 'object') {
-            // check sensitive properties in nested error object
-            this.stripErrorSensitiveProperties(errorObject[`${key}`]);
-            return;
+          if (data) {
+            if (Object.keys(data).includes('preChatResponse')) {
+              LoggingSanitizer.stripPreChatResponse(data.preChatResponse);
+            }
+            if (Object.keys(data).includes('customContextData')) {
+              LoggingSanitizer.stripCustomContextDataValues(data.customContextData);
+            }
+            LoggingSanitizer.stripGeolocation(data);
+            errorObject[key] = JSON.stringify(data); // eslint-disable-line security/detect-object-injection
           }
+        }
+        if (errorObject[`${key}`] !== null && typeof errorObject[`${key}`] === 'object') {
+          // check sensitive properties in nested error object
+          this.stripErrorSensitiveProperties(errorObject[`${key}`]);
+          return;
+        }
       });
     }
   }

--- a/src/Utils/SessionInitRetryHandler.ts
+++ b/src/Utils/SessionInitRetryHandler.ts
@@ -12,7 +12,7 @@ const sessionInitRetryHandler = (response: AxiosResponse<any> | undefined, axios
                     return false;
                 }
                 break;
-            case 400:
+            case Constants.badRequest:
                 if (parseInt(response.headers.errorcode) === Constants.outOfOfficeErrorCode) {
                     return false;
                 }

--- a/src/Utils/SessionInitRetryHandler.ts
+++ b/src/Utils/SessionInitRetryHandler.ts
@@ -5,14 +5,14 @@ import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const sessionInitRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
-    if (response && response.status) {
+    if (response?.status) {
         switch (response.status) {
             case Constants.tooManyRequestsStatusCode:
                 if (axiosRetryOptions && axiosRetryOptions.retryOn429 === false) {
                     return false;
                 }
                 break;
-            case Constants.badRequest:
+            case Constants.badRequestStatusCode:
                 if (parseInt(response.headers.errorcode) === Constants.outOfOfficeErrorCode) {
                     return false;
                 }

--- a/src/Utils/SessionInitRetryHandler.ts
+++ b/src/Utils/SessionInitRetryHandler.ts
@@ -4,7 +4,7 @@ import Constants from "../Common/Constants";
 import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const initSessionRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
+const sessionInitRetryHandler = (response: AxiosResponse<any> | undefined, axiosRetryOptions: IAxiosRetryOptions) => {
     if (response && response.status) {
         switch (response.status) {
             case Constants.tooManyRequestsStatusCode:
@@ -22,4 +22,4 @@ const initSessionRetryHandler = (response: AxiosResponse<any> | undefined, axios
     }
     return true;
 }
-export default initSessionRetryHandler;
+export default sessionInitRetryHandler;

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -26,11 +26,9 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const shouldStopExecution = (response: AxiosResponse<any> | undefined) => {
-
     if (response && response.status) {
 
       switch (response.status) {
-
         case Constants.tooManyRequestsStatusCode:
           if (axiosRetryOptions.retryOn429 === false) {
             return true;
@@ -44,7 +42,6 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
         default: return false;
       }
     }
-
     return false;
   };
 
@@ -52,7 +49,6 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
   const onError = (error: AxiosError) => {
 
     const { config, response } = error;
-
     // If we have no information of the request to retry
     if (!config) {
       return Promise.reject(error);

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -43,7 +43,7 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
       return Promise.reject(error);
     }
 
-    //evalutes if execution should stop according to the conditions defined in the handler
+    // evalutes if execution should stop according to the conditions defined in the handler
     if (axiosRetryOptions.shouldRetry && !axiosRetryOptions.shouldRetry(response)) {
       return Promise.reject(error);
     }

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -43,7 +43,7 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
       return Promise.reject(error);
     }
 
-    // evalutes if execution should stop according to the conditions defined in the handler
+    // Evaluates if execution should stop according to the conditions defined in the handler
     if (axiosRetryOptions.shouldRetry && !axiosRetryOptions.shouldRetry(response)) {
       return Promise.reject(error);
     }

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, AxiosError, AxiosResponse } from "axios";
+import { AxiosInstance, AxiosError } from "axios";
 import Constants from "../Common/Constants";
 import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 import sleep from "./sleep";
@@ -24,8 +24,7 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
   // Method to intercepts responses within range of 2xx
   const onSuccess = undefined;
 
-
-// define default behaviour for 429 retries in case the handler was not included by the caller.
+  // define default behaviour for 429 retries in case the handler was not included by the caller.
   if (!axiosRetryOptions.shouldRetry) {
     axiosRetryOptions.shouldRetry = (response) => {
       if (response && response.status && response.status === Constants.tooManyRequestsStatusCode && axiosRetryOptions.retryOn429 === false) {
@@ -44,12 +43,8 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
       return Promise.reject(error);
     }
 
-    console.log("ELOPEZANAYA => lets check if we need to stop " + JSON.stringify(response));
-
     //evalutes if execution should stop according to the conditions defined in the handler
     if (axiosRetryOptions.shouldRetry && !axiosRetryOptions.shouldRetry(response)) {
-      console.log("ELOPEZANAYA => rejecting with error => " + JSON.stringify(error));
-      console.log("ELOPEZANAYA => rejecting with response => " + JSON.stringify(response));
       return Promise.reject(error);
     }
     // Retry request if below threshold
@@ -59,7 +54,6 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
       currentTry++;
       return new Promise((resolve) => sleep(retryInterval as number | 1000).then(() => resolve(axios(config))));
     }
-
     return Promise.reject(error);
   };
 

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -44,8 +44,12 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
       return Promise.reject(error);
     }
 
+    console.log("ELOPEZANAYA => lets check if we need to stop " + JSON.stringify(response));
+
     //evalutes if execution should stop according to the conditions defined in the handler
     if (axiosRetryOptions.shouldRetry && !axiosRetryOptions.shouldRetry(response)) {
+      console.log("ELOPEZANAYA => rejecting with error => " + JSON.stringify(error));
+      console.log("ELOPEZANAYA => rejecting with response => " + JSON.stringify(response));
       return Promise.reject(error);
     }
     // Retry request if below threshold


### PR DESCRIPTION
### Description

when a widget with OOO enabled is presented during business hours. Still, the widget is launched after business hours, SDK was not detecting the 705 error code specific for OOO, and instead, it was retrying sessionInit calls causing a misleading 429 Error code.

### Solution 

- Add a mechanism to validate exceptional cases for error codes.
- add missing validation for null objects in the login helper component, (this solves a problem with multiple launches of the widget without reload)

![image](https://user-images.githubusercontent.com/981914/215240698-2b8f40e8-632a-41fc-940a-aeafaaad5ae5.png)

## Test cases
 - widget is present, and is launched after business hours , result is load pane display OOO label text.
 -  widget is present, and is launched after business hours , after hours pane is present, widget gets closed and launched again multiple times ,  result is load pane display OOO label text for each attempt
 -  widget is presentduring business hours, launched after hours, pane with offline message is shown, new business hours gets in effect and widget is launched again being able to start a chat session.

## 429 for GetchatToken ( retry and fail)

![image](https://user-images.githubusercontent.com/981914/216467841-89c17a1d-7bb6-49f7-8c74-53a6f309c6f1.png)


## 429 for sessionInit ( no retry)

![image](https://user-images.githubusercontent.com/981914/216468193-fff0b99c-7c53-4f1d-9b16-72a1d62c5ad3.png)
