### PR TITLE
Add AuthCodeNonce for OAuth 2.0 OC Communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - `livechatconnector/v3/getchattoken` endpoint
 - `livechatconnector/v3/auth/getchattoken` endpoint
 - Stop retry when the error is related to out of office hours.
+- Send and receive `AuthCodeNonce` header in order to be compliant with Omnichannel's OAuth 2.0 requirement 
 
 ## [0.3.3] - 2023-01-09
 ### Fix

--- a/src/Common/OmnichannelHTTPHeaders.ts
+++ b/src/Common/OmnichannelHTTPHeaders.ts
@@ -4,4 +4,5 @@ export default class OmnichannelHTTPHeaders {
   public static readonly organizationId = `OrganizationId`;
   public static readonly widgetAppId = `widgetAppId`;
   public static readonly requestId = `Request-Id`;
+  public static readonly authCodeNonce = `AuthCodeNonce`;
 }

--- a/src/Interfaces/IAxiosRetryOptions.ts
+++ b/src/Interfaces/IAxiosRetryOptions.ts
@@ -7,4 +7,8 @@ export default interface IAxiosRetryOptions {
    * Whether to retry on 429 HTTP status code response
    */
   retryOn429?: boolean | true;
+  /**
+   * Callback to fetch current auth nonce in case of failure and retry
+   */
+  fetchAuthCodeNonce?: () => string;
 }

--- a/src/Interfaces/IAxiosRetryOptions.ts
+++ b/src/Interfaces/IAxiosRetryOptions.ts
@@ -13,9 +13,9 @@ export default interface IAxiosRetryOptions {
    * Function to handle logic and evaluate if retry should continue based on response results.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  shouldRetry? (response? : any, axiosRetryOptions?: IAxiosRetryOptions)  : boolean
+  shouldRetry? (response? : any, axiosRetryOptions?: IAxiosRetryOptions) : boolean
   /**
-   * Callback to fetch current auth nonce in case of failure and retry
+   * Overwrite request headers on demand based on response headers of the same name
    */
-  fetchAuthCodeNonce?: () => string;
+  headerOverwrites?: string[];
 }

--- a/src/Interfaces/ISDKConfiguration.ts
+++ b/src/Interfaces/ISDKConfiguration.ts
@@ -27,4 +27,8 @@ export default interface ISDKConfiguration {
    * Individual Request timeouts
    */
   requestTimeoutConfig: RequestTimeoutConfig;
+  /**
+   * Nonce for Auth V2 requests
+   */
+  authCodeNonce: string;
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -171,7 +171,7 @@ export default class SDK implements ISDK {
     // construct a endpoint for anonymous chats to get LWI Details
     let requestPath = `/${OmnichannelEndpoints.LiveChatLiveWorkItemDetailsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     // Extract auth token and reconnect id from optional param
     const { authenticatedUserToken, reconnectId } = getLWIDetailsOptionalParams;
@@ -204,10 +204,7 @@ export default class SDK implements ISDK {
         const response = await axiosInstance(options);
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
-
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLWISTATUSSUCCEEDED, "Get LWI Details succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
         resolve(data);
@@ -268,7 +265,7 @@ export default class SDK implements ISDK {
     };
 
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure, retryOn429: this.configuration.getChatTokenRetryOn429 });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure, retryOn429: this.configuration.getChatTokenRetryOn429 });
 
     return new Promise(async (resolve, reject) => {
       let getChatTokenError = undefined;
@@ -276,14 +273,11 @@ export default class SDK implements ISDK {
         const response = await axiosInstance(options);
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
+        this.setAuthCodeNonce(headers);
 
         // Resolves only if it contains chat token response which only happens on status 200
         if (data) {
           data.requestId = requestId;
-
-          if (headers?.authcodenonce) {
-            this.configuration.authCodeNonce = headers?.authcodenonce;
-          }
 
           this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTOKENSUCCEEDED, "Get Chat Token succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
 
@@ -360,10 +354,7 @@ export default class SDK implements ISDK {
         const response = await axiosInstance(options);
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
-
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         // Resolves only if it contains reconnectable chats response which only happens on status 200
         if (data) {
@@ -446,7 +437,7 @@ export default class SDK implements ISDK {
 
     const requestPath = `/${OmnichannelEndpoints.GetAgentAvailabilityPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}?channelId=lcw`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken, initContext, getContext } = queueAvailabilityOptionalParams;
 
@@ -511,11 +502,9 @@ export default class SDK implements ISDK {
         const response = await axiosInstance(options);
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
+        this.setAuthCodeNonce(headers);
+        
         if (data) {
-          if (headers?.authcodenonce) {
-            this.configuration.authCodeNonce = headers?.authcodenonce;
-          }
-
           this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETAGENTAVAILABILITYSUCCEEDED, "Get agent availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
 
           resolve(data);
@@ -544,7 +533,7 @@ export default class SDK implements ISDK {
     axiosRetry(axiosInstance, {
       retries: this.configuration.maxRequestRetriesOnFailure,
       shouldRetry: sessionInitRetryHandler,
-      fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this)
+      headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce]
     });
 
     const { reconnectId, authenticatedUserToken, initContext, getContext } = sessionInitOptionalParams;
@@ -598,9 +587,7 @@ export default class SDK implements ISDK {
       const response = await axiosInstance(options);
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { headers } = response;
-      if (headers?.authcodenonce) {
-        this.configuration.authCodeNonce = headers?.authcodenonce;
-      }
+      this.setAuthCodeNonce(headers);
 
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data);
     } catch (error) {
@@ -624,7 +611,7 @@ export default class SDK implements ISDK {
 
     let requestPath = `/${OmnichannelEndpoints.LiveChatSessionClosePath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken, isReconnectChat, isPersistentChat, chatId } = sessionCloseOptionalParams;
 
@@ -659,10 +646,8 @@ export default class SDK implements ISDK {
     return new Promise(async (resolve, reject) => {
       try {
         const response = await axiosInstance(options);
-        const { headers } = response;
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        const { headers } = response;  
+        this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONCLOSESUCCEEDED, "Session Close succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
@@ -690,7 +675,7 @@ export default class SDK implements ISDK {
     const { authenticatedUserToken, chatId } = validateAuthChatRecordOptionalParams;
     const requestPath = `/${OmnichannelEndpoints.LiveChatValidateAuthChatMapRecordPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${chatId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
     const headers: StringMap = Constants.defaultHeaders;
     if (authenticatedUserToken) {
       headers[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
@@ -708,11 +693,8 @@ export default class SDK implements ISDK {
 
     try {
       const response = await axiosInstance(options);
-      
       const { headers } = response;
-      if (headers?.authcodenonce) {
-        this.configuration.authCodeNonce = headers?.authcodenonce;
-      }
+      this.setAuthCodeNonce(headers);
 
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       if (response.data?.authChatExist === true) {
@@ -753,7 +735,7 @@ export default class SDK implements ISDK {
 
     let requestPath = `/${OmnichannelEndpoints.LiveChatSubmitPostChatPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken } = submitPostChatResponseOptionalParams;
 
@@ -778,11 +760,8 @@ export default class SDK implements ISDK {
     return new Promise(async (resolve, reject) => {
       try {
         const response = await axiosInstance(options);
-        
         const { headers } = response;
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SUBMITPOSTCHATSUCCEEDED, "Submit Post Chat succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
@@ -815,7 +794,7 @@ export default class SDK implements ISDK {
     }
     let requestPath = `/${OmnichannelEndpoints.LiveChatGetSurveyInviteLinkPath}/${this.omnichannelConfiguration.orgId}/${surveyOwnerId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken, requestId } = getsurveyInviteLinkOptionalParams;
 
@@ -846,9 +825,7 @@ export default class SDK implements ISDK {
       try {
         const response = await axiosInstance(options);
         const { data, headers } = response;
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
@@ -878,7 +855,7 @@ export default class SDK implements ISDK {
 
     let requestPath = `/${OmnichannelEndpoints.LiveChatGetChatTranscriptPath}/${chatId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken, currentLiveChatVersion } = getChatTranscriptsOptionalParams;
 
@@ -915,9 +892,7 @@ export default class SDK implements ISDK {
         const response = await axiosInstance(options);
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
 
@@ -946,7 +921,7 @@ export default class SDK implements ISDK {
 
     let requestPath = `/${OmnichannelEndpoints.LiveChatTranscriptEmailRequestPath}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken } = emailTranscriptOptionalParams;
 
@@ -975,9 +950,7 @@ export default class SDK implements ISDK {
       try {
         const response = await axiosInstance(options);
         const { headers } = response;
-        if (headers?.authcodenonce) {
-          this.configuration.authCodeNonce = headers?.authcodenonce;
-        }
+        this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
@@ -1053,7 +1026,7 @@ export default class SDK implements ISDK {
 
     let requestPath = `/${OmnichannelEndpoints.LiveChatSecondaryChannelEventPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
     const axiosInstance = axios.create();
-    axiosRetry(axiosInstance, { fetchAuthCodeNonce: this.fetchAuthCodeNonce.bind(this),  retries: this.configuration.maxRequestRetriesOnFailure });
+    axiosRetry(axiosInstance, { headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce], retries: this.configuration.maxRequestRetriesOnFailure });
 
     const { authenticatedUserToken } = secondaryChannelEventOptionalParams;
 
@@ -1081,9 +1054,7 @@ export default class SDK implements ISDK {
     try {
       const response = await axiosInstance(options);
       const { headers } = response;
-      if (headers?.authcodenonce) {
-        this.configuration.authCodeNonce = headers?.authcodenonce;
-      }
+      this.setAuthCodeNonce(headers);
 
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method);
@@ -1197,5 +1168,12 @@ export default class SDK implements ISDK {
 
   private fetchAuthCodeNonce(): string {
     return this.configuration.authCodeNonce;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private setAuthCodeNonce = (headers: any) => {
+    if (headers?.authcodenonce) {
+      this.configuration.authCodeNonce = headers?.authcodenonce;
+    }
   }
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1166,10 +1166,6 @@ export default class SDK implements ISDK {
     this.logger.log(logLevel, telemetryEventType, customData, description);
   }
 
-  private fetchAuthCodeNonce(): string {
-    return this.configuration.authCodeNonce;
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private setAuthCodeNonce = (headers: any) => {
     if (headers?.authcodenonce) {

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -18,7 +18,7 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
     axiosRetryOptions.retryOn429 = true;
   }
 
-  const { retries, fetchAuthCodeNonce } = axiosRetryOptions;
+  const { retries, headerOverwrites } = axiosRetryOptions;
 
   let currentTry = 1; // Executed as soon as after 1st try
 
@@ -54,9 +54,14 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
     if (shouldRetry) {
       currentTry++;
 
-      if (fetchAuthCodeNonce) {
-        const nonce = fetchAuthCodeNonce();
-        config.headers[OmnichannelHTTPHeaders.authCodeNonce] = nonce;
+      if (headerOverwrites && response?.headers) {
+        for (const headerName of headerOverwrites) {
+          const responseHeader = response?.headers[headerName.toLocaleLowerCase()];
+          if (responseHeader) {
+            // eslint-disable-next-line security/detect-object-injection
+            config.headers[headerName] = responseHeader;
+          }
+        }
       }
 
       return new Promise((resolve) => sleep(retryInterval as number | 1000).then(() => resolve(axios(config))));

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance, AxiosError } from "axios";
 import Constants from "../Common/Constants";
+import OmnichannelHTTPHeaders from "../Common/OmnichannelHTTPHeaders";
 import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 import sleep from "./sleep";
 
@@ -17,7 +18,7 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
     axiosRetryOptions.retryOn429 = true;
   }
 
-  const { retries } = axiosRetryOptions;
+  const { retries, fetchAuthCodeNonce } = axiosRetryOptions;
 
   let currentTry = 1; // Executed as soon as after 1st try
 
@@ -43,6 +44,12 @@ const axiosRetry = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryOptions)
 
     if (shouldRetry) {
       currentTry++;
+
+      if (fetchAuthCodeNonce) {
+        const nonce = fetchAuthCodeNonce();
+        config.headers[OmnichannelHTTPHeaders.authCodeNonce] = nonce;
+      }
+
       return new Promise((resolve) => sleep(retryInterval as number| 1000).then(() => resolve(axios(config))));
     }
 

--- a/src/Utils/axiosRetry.ts
+++ b/src/Utils/axiosRetry.ts
@@ -1,6 +1,5 @@
 import { AxiosInstance, AxiosError } from "axios";
 import Constants from "../Common/Constants";
-import OmnichannelHTTPHeaders from "../Common/OmnichannelHTTPHeaders";
 import IAxiosRetryOptions from "../Interfaces/IAxiosRetryOptions";
 import sleep from "./sleep";
 


### PR DESCRIPTION
Changes: 

1. Put nonce value in configuration (with default) which will be used when sending auth requests
2. Update said nonce if we receive AuthCodeNonce header in response (sent by ChannelConnector)
3. Pass a callback function to axiosRetry so that retries are also honoring the nonce update logic