### PR TITLE
Increasing timeout and add special error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - `livechatconnector/v3/auth/getchattoken` endpoint
 - Stop retry when the error is related to out of office hours.
 - Send and receive `AuthCodeNonce` header in order to be compliant with Omnichannel's OAuth 2.0 requirement 
+- Increasing request timeout and add error handling for OAuth 2.0
 
 ## [0.3.3] - 2023-01-09
 ### Fix


### PR DESCRIPTION
1. Further increase request timeout to accommodate OC Auth 2.0 changes. No more increases after this. Will use props to configure in LCW 2.0
2. Make sure all call failures return error object to the caller. This is so that LCW can raise custom error after parsing the error object