### PR TITLE
updated retryOn429 flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const params = {
 const configuration = {
   getChatTokenRetryCount: 35,
   getChatTokenTimeBetweenRetriesOnFailure: 10000,
-  maxRequestRetriesOnFailure: 3
+  maxRequestRetriesOnFailure: 5
 };
 
 const ocsdk = Microsoft.CRM.Omnichannel.SDK.SDKProvider.getSDK(params, configuration);
@@ -243,7 +243,7 @@ These are the available config options with its default values for the SDK.
   /**
    * Maximum number of request retries before failing.
    */
-  maxRequestRetriesOnFailure: 3,
+  maxRequestRetriesOnFailure: 5,
 }
 ```
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -72,7 +72,7 @@ export default class SDK implements ISDK {
     authCodeNonce: uuidv4().substring(0, 8),
     getChatTokenRetryCount: 10,
     getChatTokenTimeBetweenRetriesOnFailure: 10000,
-    getChatTokenRetryOn429: false,
+    getChatTokenRetryOn429: true,
     maxRequestRetriesOnFailure: 3,
     defaultRequestTimeout: undefined,
     requestTimeoutConfig: SDK.defaultRequestTimeoutConfig,
@@ -624,7 +624,7 @@ export default class SDK implements ISDK {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSTARTED, "Session Init Started", requestId);
     const axiosInstance = axios.create();
-    const retryOn429 = false;
+    const retryOn429 = true;
     axiosRetryHandler(axiosInstance, {
       retries: this.configuration.maxRequestRetriesOnFailure,
       waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.sessionInit,

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -72,7 +72,7 @@ export default class SDK implements ISDK {
     authCodeNonce: uuidv4().substring(0, 8),
     getChatTokenRetryCount: 10,
     getChatTokenTimeBetweenRetriesOnFailure: 10000,
-    getChatTokenRetryOn429: true,
+    getChatTokenRetryOn429: false,
     maxRequestRetriesOnFailure: 3,
     defaultRequestTimeout: undefined,
     requestTimeoutConfig: SDK.defaultRequestTimeoutConfig,
@@ -624,7 +624,7 @@ export default class SDK implements ISDK {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSTARTED, "Session Init Started", requestId);
     const axiosInstance = axios.create();
-    const retryOn429 = true;
+    const retryOn429 = false;
     axiosRetryHandler(axiosInstance, {
       retries: this.configuration.maxRequestRetriesOnFailure,
       waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.sessionInit,

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -73,7 +73,7 @@ export default class SDK implements ISDK {
     getChatTokenRetryCount: 10,
     getChatTokenTimeBetweenRetriesOnFailure: 10000,
     getChatTokenRetryOn429: true,
-    maxRequestRetriesOnFailure: 3,
+    maxRequestRetriesOnFailure: 5,
     defaultRequestTimeout: undefined,
     requestTimeoutConfig: SDK.defaultRequestTimeoutConfig,
     useUnauthReconnectIdSigQueryParam: false,

--- a/src/Utils/axiosRetryHandler.ts
+++ b/src/Utils/axiosRetryHandler.ts
@@ -66,7 +66,7 @@ const axiosRetryHandler = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryO
       }
       if(error.response?.status === Constants.tooManyRequestsStatusCode){
         // Retry after 5 seconds for 429 status code
-        return retryCount * 5000;
+        return 5000;
       }
       return Math.pow(2, retryCount) * timeBetweenRetry;
     },

--- a/src/Utils/axiosRetryHandler.ts
+++ b/src/Utils/axiosRetryHandler.ts
@@ -64,6 +64,10 @@ const axiosRetryHandler = (axios: AxiosInstance, axiosRetryOptions: IAxiosRetryO
         }
         return retryAfterTime;
       }
+      if(error.response?.status === Constants.tooManyRequestsStatusCode){
+        // Retry after 5 seconds for 429 status code
+        return retryCount * 5000;
+      }
       return Math.pow(2, retryCount) * timeBetweenRetry;
     },
 


### PR DESCRIPTION
- updated 429 status logic for getChatToken and sessionInit api endpoints.
- updated maxRequestRetriesOnFailure to 5 we will be retrying each failed api call 5 times.
- for failed api call with 429 status we are retrying api call after 5 secs.


1)Session init: Do not retry on 429 status
 
![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/f8bd14a3-dde8-4256-a98d-e824fab893af)

 2) getChatToken: Do not retry on 429 error status code
 
![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/c3372b77-45ad-4a9f-86c0-0550e566b317)

3.OOO scenario: 
axios retry handler will not retry on 400 and error code 705
 
![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/69d9297c-9f71-4c82-85ec-bd7088a1b697)

 
4) For other api endpoints which don’t have retryOn429 flag
we will not be retrying api call for 429 status code
![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/0222fc75-6ac7-471f-9639-54be727dcef7)

 5) Headers
 ![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/94f457fc-3043-4500-aabd-6a805986d746)

6)	For status code 500x we will retry failed api call 3 times
![image](https://github.com/microsoft/omnichannel-sdk/assets/128818969/26e0082a-da83-44c6-8e97-79a54cc5e6dd)


 

