### PR TITLE
UpdateRetry handler to retry when there is 404 for getLWDetails api call

### DIFF
--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -13,6 +13,7 @@ export default class Constants {
   public static readonly defaultLocale = "en-us";
   public static readonly noContentStatusCode = 204;
   public static readonly tooManyRequestsStatusCode = 429;
+  public static readonly notFoundStatusCode = 404;
   public static readonly badRequestStatusCode = 400;
   public static readonly outOfOfficeErrorCode = 705;
   public static readonly sensitiveProperties = ["AuthenticatedUserToken"];

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -41,7 +41,7 @@ import { RequestTimeoutConfig } from "./Common/RequestTimeoutConfig";
 import { StringMap } from "./Common/Mappings";
 import { Timer } from "./Utils/Timer";
 import { addOcUserAgentHeader } from "./Utils/httpHeadersUtils";
-import axiosRetryHandler from "./Utils/axiosRetryHandler";
+import axiosRetryHandler, { axiosRetryHandlerWithNotFound } from "./Utils/axiosRetryHandler";
 import { createGetChatTokenEndpoint } from "./Utils/endpointsCreators";
 import isExpectedAxiosError from "./Utils/isExpectedAxiosError";
 import sessionInitRetryHandler from "./Utils/SessionInitRetryHandler";
@@ -229,10 +229,10 @@ export default class SDK implements ISDK {
     // construct a endpoint for anonymous chats to get LWI Details
     let requestPath = `/${OmnichannelEndpoints.LiveChatLiveWorkItemDetailsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
     const axiosInstance = axios.create();
-    axiosRetryHandler(axiosInstance, {
+    axiosRetryHandlerWithNotFound(axiosInstance, {
       headerOverwrites: [OmnichannelHTTPHeaders.authCodeNonce],
       retries: this.configuration.maxRequestRetriesOnFailure,
-      waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.getLWIDetails
+      waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.getLWIDetails,
     });
 
     // Extract auth token and reconnect id from optional param

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -60,6 +60,7 @@ describe("SDK unit tests", () => {
         dataMock = { data: { requestId: "someId" } };
         uuidvSpy = spyOn(uuidvModule, "uuidv4").and.returnValue("reqId");
         spyOn(axiosRetryHandler, "default").and.callFake(() => {});
+        spyOn(axiosRetryHandler, "axiosRetryHandlerWithNotFound").and.callFake(() => {});
         axiosInstMock = jasmine.createSpy("axiosInstance").and.returnValue(dataMock);
         axiosInstMockWithError = jasmine.createSpy("axiosInstance").and.throwError(AxiosError);
         axiosInstEmptyMock = jasmine.createSpy("axiosInstance").and.returnValue({data: {}});
@@ -165,7 +166,7 @@ describe("SDK unit tests", () => {
             sdk.getLWIDetails("");
             expect(uuidvSpy).toHaveBeenCalled();
             expect(axios.create).toHaveBeenCalled();
-            expect(axiosRetryHandler.default).toHaveBeenCalled();
+            expect(axiosRetryHandler.axiosRetryHandlerWithNotFound).toHaveBeenCalled();
             expect(ocsdkLogger.log).toHaveBeenCalled();
         });
 
@@ -176,7 +177,8 @@ describe("SDK unit tests", () => {
         sdk.getLWIDetails("");
         expect(uuidvSpy).toHaveBeenCalled();
         expect(axios.create).toHaveBeenCalled();
-        expect(axiosRetryHandler.default).toHaveBeenCalled();
+      
+        expect(axiosRetryHandler.axiosRetryHandlerWithNotFound).toHaveBeenCalled();
         expect(ocsdkLogger.log).not.toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
getLWDetails api call return 404 if called immediately after start chat. Implementing retry so that it retries to get the liveworkitem details