### PR TITLE
logging errorCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- loging response errorCode into telemetry logs
+- logging response errorCode into telemetry logs
 - Improve telemetry to uniformly log all errors for reconnectable chat and reconnect availability
 
 ## [0.5.6]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-
+- loging response errorCode into telemetry logs
 - Improve telemetry to uniformly log all errors for reconnectable chat and reconnect availability
 
 ## [0.5.6]

--- a/src/Model/IOCSDKLogData.ts
+++ b/src/Model/IOCSDKLogData.ts
@@ -10,4 +10,5 @@ export default interface IOCSDKLogData {
   RequestPath?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   RequestMethod?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   RequestHeaders?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  ResponseErrorCode?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1350,7 +1350,8 @@ export default class SDK implements ISDK {
       ResponseStatusCode: response ? response.status : error ? (error as any).response?.status : undefined, // eslint-disable-line @typescript-eslint/no-explicit-any
       ExceptionDetails: error,
       RequestPayload: sanitizedRequestPayload,
-      RequestHeaders: sanitizedRequestHeaders
+      RequestHeaders: sanitizedRequestHeaders,
+      ResponseErrorcode: error ? (error as any).response?.headers?.errorcode : undefined // eslint-disable-line @typescript-eslint/no-explicit-any
     };
     this.logger.log(logLevel, telemetryEventType, customData, description);
   }

--- a/src/Utils/TelemetryHelper.ts
+++ b/src/Utils/TelemetryHelper.ts
@@ -17,7 +17,8 @@ export default class TelemetryHelper {
       RequestPayload: customData.RequestPayload,
       RequestPath: customData.RequestPath,
       RequestMethod: customData.RequestMethod,
-      ResponseStatusCode: customData.ResponseStatusCode
+      ResponseStatusCode: customData.ResponseStatusCode,
+      ResponseErrorcode: customData.ResponseErrorcode,
     };
 
     return logData;


### PR DESCRIPTION
Logging ResponseErrorCode into telemetry to understand if api is failed due to expected reason. so that this can be ignored in monitor 