### PR TITLE
Fix Reconnectable Chats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - logging response errorCode into telemetry logs
 - Improve telemetry to uniformly log all errors for reconnectable chat and reconnect availability
 
+### Fixed
+- Add `requestId` as optional parameters for `getReconnectableChats()`
+
 ## [0.5.6]
 
 ### Fixed

--- a/src/Interfaces/IReconnectableChatsParams.ts
+++ b/src/Interfaces/IReconnectableChatsParams.ts
@@ -3,4 +3,5 @@ export default interface IReconnectableChatsParams {
    * JWT token from the portal
    */
   authenticatedUserToken: string;
+  requestId?: string;
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -421,7 +421,7 @@ export default class SDK implements ISDK {
     const { authenticatedUserToken } = reconnectableChatsParams;
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSTARTED, "Get Reconnectable chat Started");
 
-    const requestPath = `/${OmnichannelEndpoints.LiveChatGetReconnectableChatsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${this.omnichannelConfiguration.orgId}?channelId=${this.omnichannelConfiguration.channelId}`;
+    const requestPath = `/${OmnichannelEndpoints.LiveChatGetReconnectableChatsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${reconnectableChatsParams?.requestId || this.omnichannelConfiguration.orgId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const requestHeaders: StringMap = Constants.defaultHeaders;
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;


### PR DESCRIPTION
- Add `requestId` as optional parameter for `SDK.getReconnectableChat()`