### PR TITLE
Update timeout getconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- Increase of timeout limit time for GetChatConfig, from 30 secs to 120 secs.
 
 ## [0.5.7] - 2024-10-25
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -50,7 +50,7 @@ import { waitTimeBetweenRetriesConfigs } from "./Utils/waitTimeBetweenRetriesCon
 
 export default class SDK implements ISDK {
   private static defaultRequestTimeoutConfig: RequestTimeoutConfig = {
-    getChatConfig: 30000,
+    getChatConfig: 120000,
     getLWIDetails: 15000,
     getChatToken: 15000,
     sessionInit: 15000,


### PR DESCRIPTION
Increase time for GetChatConfig , to avoid network timeout for regions with slow connections.