### PR TITLE
Users/mithunj/correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added correlationId in the header for all oc request
+
 ## [0.5.14] 2025-04-09
 
 ### Added

--- a/src/Common/OmnichannelHTTPHeaders.ts
+++ b/src/Common/OmnichannelHTTPHeaders.ts
@@ -7,4 +7,5 @@ export default class OmnichannelHTTPHeaders {
   public static readonly authCodeNonce = `AuthCodeNonce`;
   public static readonly ocSessionId = `Oc-Sessionid`;
   public static readonly ocUserAgent = `Ms-Oc-User-Agent`;
+  public static readonly correlationId = `x-ms-client-request-id`;
 }

--- a/src/Interfaces/IReconnectAvailabilityOptionalParams.ts
+++ b/src/Interfaces/IReconnectAvailabilityOptionalParams.ts
@@ -1,0 +1,4 @@
+export default interface IReconnectAvailabilityOptionalParams {
+    requestId?: string;
+  }
+  

--- a/src/Interfaces/IReconnectAvailabilityOptionalParams.ts
+++ b/src/Interfaces/IReconnectAvailabilityOptionalParams.ts
@@ -1,4 +1,4 @@
 export default interface IReconnectAvailabilityOptionalParams {
-    requestId?: string;
-  }
+  requestId?: string;
+}
   

--- a/src/Interfaces/ISDK.ts
+++ b/src/Interfaces/ISDK.ts
@@ -12,7 +12,7 @@ export default interface ISDK {
   createConversation(requestId: string): Promise<FetchChatTokenResponse>;
   sessionClose(requestId: string): Promise<void>;
   getReconnectableChats(reconnectableChatsParams: IReconnectableChatsParams): Promise<object | void>;
-  getReconnectAvailability(reconnectId: string): Promise<object | void>;
+  getReconnectAvailability(reconnectId: string, requestId: string): Promise<object | void>;
   submitPostChatResponse(requestId: string, postChatResponse: object): Promise<void>;
   getSurveyInviteLink(surveyOwnerId: string, surveyInviteAPIRequestBody: object): Promise<object>;
   getChatTranscripts(requestId: string, chatId: string, token: string): Promise<string>;

--- a/src/Interfaces/ISDK.ts
+++ b/src/Interfaces/ISDK.ts
@@ -2,6 +2,7 @@ import FetchChatTokenResponse from "../Model/FetchChatTokenResponse";
 import IDataMaskingInfo from "../Interfaces/IDataMaskingInfo";
 import IGetQueueAvailabilityOptionalParams from "./IGetQueueAvailabilityOptionalParams";
 import IReconnectableChatsParams from "../Interfaces/IReconnectableChatsParams";
+import IReconnectAvailabilityOptionalParams from "./IReconnectAvailabilityOptionalParams";
 
 export default interface ISDK {
   getLcwFcsDetails(): Promise<object | void>;
@@ -12,7 +13,7 @@ export default interface ISDK {
   createConversation(requestId: string): Promise<FetchChatTokenResponse>;
   sessionClose(requestId: string): Promise<void>;
   getReconnectableChats(reconnectableChatsParams: IReconnectableChatsParams): Promise<object | void>;
-  getReconnectAvailability(reconnectId: string, requestId: string): Promise<object | void>;
+  getReconnectAvailability(reconnectId: string, optionalParams: IReconnectAvailabilityOptionalParams): Promise<object | void>;
   submitPostChatResponse(requestId: string, postChatResponse: object): Promise<void>;
   getSurveyInviteLink(surveyOwnerId: string, surveyInviteAPIRequestBody: object): Promise<object>;
   getChatTranscripts(requestId: string, chatId: string, token: string): Promise<string>;

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -247,9 +247,7 @@ export default class SDK implements ISDK {
       requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
     }
 
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     // If should only be applicable on unauth chat & the flag enabled
     const shouldUseSigQueryParam = !authenticatedUserToken && this.configuration.useUnauthReconnectIdSigQueryParam === true;
@@ -433,9 +431,7 @@ export default class SDK implements ISDK {
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(reconnectableChatsParams?.requestId, requestHeaders);
+    this.addDefaultHeaders(reconnectableChatsParams?.requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -489,9 +485,7 @@ export default class SDK implements ISDK {
     const requestPath = `/${OmnichannelEndpoints.LiveChatReconnectAvailabilityPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${reconnectId}`;
     const requestHeaders: StringMap = Constants.defaultHeaders;
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -557,9 +551,7 @@ export default class SDK implements ISDK {
       requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const data: InitContext = initContext || {};
 
@@ -668,10 +660,9 @@ export default class SDK implements ISDK {
       });
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
     this.setRequestIdHeader(requestId, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+
 
     // If should only be applicable on unauth chat & the flag enabled
     const shouldUseSigQueryParam = !authenticatedUserToken && this.configuration.useUnauthReconnectIdSigQueryParam === true;
@@ -771,10 +762,8 @@ export default class SDK implements ISDK {
       });
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
     this.setRequestIdHeader(requestId, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (reconnectId) {
       data.reconnectId = reconnectId;
@@ -873,9 +862,7 @@ export default class SDK implements ISDK {
       requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     if (isReconnectChat) {
       requestPath += `&isReconnectChat=true`;
@@ -941,9 +928,7 @@ export default class SDK implements ISDK {
       requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1083,9 +1068,7 @@ export default class SDK implements ISDK {
       requestHeaders[OmnichannelHTTPHeaders.widgetAppId] = this.omnichannelConfiguration.widgetId;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     if (requestId) {
       requestHeaders[OmnichannelHTTPHeaders.requestId] = requestId;
@@ -1160,9 +1143,7 @@ export default class SDK implements ISDK {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthGetChatTranscriptPath}/${chatId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1225,9 +1206,7 @@ export default class SDK implements ISDK {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthTranscriptEmailRequestPath}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -1281,9 +1260,7 @@ export default class SDK implements ISDK {
     requestHeaders[OmnichannelHTTPHeaders.organizationId] = this.omnichannelConfiguration.orgId;
     requestHeaders[OmnichannelHTTPHeaders.requestId] = requestId;
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1340,9 +1317,7 @@ export default class SDK implements ISDK {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthSecondaryChannelEventPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}`;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     requestPath += "?channelId=" + Constants.defaultChannelId;
 
@@ -1396,9 +1371,7 @@ export default class SDK implements ISDK {
       requestHeaders[Constants.customerDisplayName] = customerDisplayName;
     }
 
-    this.setSessionIdHeader(this.sessionId, requestHeaders);
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -1514,6 +1487,12 @@ export default class SDK implements ISDK {
     if (headers?.authcodenonce) {
       this.configuration.authCodeNonce = headers?.authcodenonce;
     }
+  }
+
+  private addDefaultHeaders(requestId: string | undefined, requestHeaders: StringMap): void {
+    this.setSessionIdHeader(this.sessionId, requestHeaders);
+    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -477,14 +477,14 @@ export default class SDK implements ISDK {
  * Fetches the reconnectable chats from omnichannel from the given user information in JWT token(claim name: sub).
  * @param reconnectableChatsParams Mandate parameters for get reconnectable chats.
  */
-  public async getReconnectAvailability(reconnectId: string, optionalParam: IReconnectAvailabilityOptionalParams = {}): Promise<ReconnectAvailability | void> {
+  public async getReconnectAvailability(reconnectId: string, optionalParams: IReconnectAvailabilityOptionalParams = {}): Promise<ReconnectAvailability | void> {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSTARTED, "Get Reconnectable availability Started");
 
     const requestPath = `/${OmnichannelEndpoints.LiveChatReconnectAvailabilityPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${reconnectId}`;
     const requestHeaders: StringMap = Constants.defaultHeaders;
 
-    this.addDefaultHeaders(optionalParam?.requestId, requestHeaders);
+    this.addDefaultHeaders(optionalParams?.requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -502,19 +502,19 @@ export default class SDK implements ISDK {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParam?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
 
           resolve(data);
           return;
         }
         // No data found so returning null
-        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParam?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
 
         resolve();
         return;
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", optionalParam?.requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", optionalParams?.requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -182,8 +182,7 @@ export default class SDK implements ISDK {
     });
 
     let requestHeaders = {};
-    addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
-    this.setCorrelationIdInHeader(requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     if (bypassCache) {
       requestHeaders = { ...Constants.bypassCacheHeaders, ...requestHeaders };

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -182,6 +182,7 @@ export default class SDK implements ISDK {
 
     let requestHeaders = {};
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (bypassCache) {
       requestHeaders = { ...Constants.bypassCacheHeaders, ...requestHeaders };
@@ -248,6 +249,7 @@ export default class SDK implements ISDK {
 
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
     this.setSessionIdHeader(this.sessionId, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     // If should only be applicable on unauth chat & the flag enabled
     const shouldUseSigQueryParam = !authenticatedUserToken && this.configuration.useUnauthReconnectIdSigQueryParam === true;
@@ -318,6 +320,7 @@ export default class SDK implements ISDK {
 
     const requestHeaders: StringMap = Constants.defaultHeaders;
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const endpoint = createGetChatTokenEndpoint(currentLiveChatVersion as LiveChatVersion || this.liveChatVersion, authenticatedUserToken ? true : false, multiBot);
 
@@ -432,6 +435,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(reconnectableChatsParams?.requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -478,7 +482,7 @@ export default class SDK implements ISDK {
  * Fetches the reconnectable chats from omnichannel from the given user information in JWT token(claim name: sub).
  * @param reconnectableChatsParams Mandate parameters for get reconnectable chats.
  */
-  public async getReconnectAvailability(reconnectId: string): Promise<ReconnectAvailability | void> {
+  public async getReconnectAvailability(reconnectId: string, requestId: string): Promise<ReconnectAvailability | void> {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSTARTED, "Get Reconnectable availability Started");
 
@@ -487,6 +491,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -504,19 +509,19 @@ export default class SDK implements ISDK {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", undefined, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
 
           resolve(data);
           return;
         }
         // No data found so returning null
-        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", undefined, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
 
         resolve();
         return;
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", undefined, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -554,6 +559,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const data: InitContext = initContext || {};
 
@@ -665,6 +671,7 @@ export default class SDK implements ISDK {
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
     this.setRequestIdHeader(requestId, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     // If should only be applicable on unauth chat & the flag enabled
     const shouldUseSigQueryParam = !authenticatedUserToken && this.configuration.useUnauthReconnectIdSigQueryParam === true;
@@ -767,6 +774,7 @@ export default class SDK implements ISDK {
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
     this.setRequestIdHeader(requestId, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (reconnectId) {
       data.reconnectId = reconnectId;
@@ -867,6 +875,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (isReconnectChat) {
       requestPath += `&isReconnectChat=true`;
@@ -934,6 +943,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1000,6 +1010,7 @@ export default class SDK implements ISDK {
 
     const { authenticatedUserToken } = submitPostChatResponseOptionalParams;
     const requestHeaders: StringMap = Constants.defaultHeaders;
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (authenticatedUserToken) {
       requestPath = `/${OmnichannelEndpoints.LiveChatAuthSubmitPostChatPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
@@ -1074,6 +1085,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     if (requestId) {
       requestHeaders[OmnichannelHTTPHeaders.requestId] = requestId;
@@ -1150,6 +1162,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1214,6 +1227,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -1269,6 +1283,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -1327,6 +1342,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     requestPath += "?channelId=" + Constants.defaultChannelId;
 
@@ -1382,6 +1398,7 @@ export default class SDK implements ISDK {
 
     this.setSessionIdHeader(this.sessionId, requestHeaders);
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
+    this.setCorrelationIdInHeader(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "POST";
@@ -1509,6 +1526,12 @@ export default class SDK implements ISDK {
   private setRequestIdHeader = (requestId: string | undefined, headers: StringMap) => {
     if (requestId) {
       headers[OmnichannelHTTPHeaders.requestId] = requestId;
+    }
+  }
+
+  private setCorrelationIdInHeader = (correlationId: string | undefined, headers: StringMap) => {
+    if (correlationId) {
+      headers[OmnichannelHTTPHeaders.correlationId] = correlationId;
     }
   }
 }


### PR DESCRIPTION
 Set x-ms-client-request-id header on all requests to OC backend for correlation tracking


![image](https://github.com/user-attachments/assets/90b4e1e4-b3d1-4a44-81b5-b6d31ad7a003)
