### PR TITLE
updating reconnectableAPI call to use requestID instead of org id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Updated request id path parameter in getReconnectable Api to standardize the use
+- Removed Timeout from telemetry logger
 
 ## [0.5.15] 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated request id path parameter in getReconnectable Api to standardize the use
+
 ## [0.5.15] 2025-05-09
 
 ### Added

--- a/src/Common/OCSDKLogger.ts
+++ b/src/Common/OCSDKLogger.ts
@@ -21,7 +21,7 @@ export default class OCSDKLogger implements IOCSDKLogger {
 
   public logEvent(logLevel: LogLevel, logData: IOCSDKLogData): number | void {
     if (this.isLoggingEnabled()) {
-        setTimeout(this.logger.logClientSdkTelemetryEvent.bind(this.logger), 0, logLevel, logData);
+        this.logger.logClientSdkTelemetryEvent(logLevel, logData);
     }
   }
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -424,13 +424,14 @@ export default class SDK implements ISDK {
     const timer = Timer.TIMER();
     const { authenticatedUserToken } = reconnectableChatsParams;
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSTARTED, "Get Reconnectable chat Started");
+    const requestId = reconnectableChatsParams?.requestId;
 
-    const requestPath = `/${OmnichannelEndpoints.LiveChatGetReconnectableChatsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${reconnectableChatsParams?.requestId || this.omnichannelConfiguration.orgId}?channelId=${this.omnichannelConfiguration.channelId}`;
+    const requestPath = `/${OmnichannelEndpoints.LiveChatGetReconnectableChatsPath}/${this.omnichannelConfiguration.orgId}/${this.omnichannelConfiguration.widgetId}/${requestId}?channelId=${this.omnichannelConfiguration.channelId}`;
     const requestHeaders: StringMap = Constants.defaultHeaders;
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
 
-    this.addDefaultHeaders(reconnectableChatsParams?.requestId, requestHeaders);
+    this.addDefaultHeaders(requestId, requestHeaders);
 
     const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
     const method = "GET";
@@ -442,8 +443,6 @@ export default class SDK implements ISDK {
     };
 
     const axiosInstance = axios.create();
-
-    const requestId = this.omnichannelConfiguration.orgId;
 
     return new Promise(async (resolve, reject) => {
       try {


### PR DESCRIPTION
This pull request includes changes to standardize the use of the `requestId` parameter, improve logging behavior, and update the changelog. The most important changes involve modifying the `requestId` handling in the SDK and removing unnecessary asynchronous behavior in the logger.

