### PR TITLE
Bumpv0.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.15] 2025-05-12
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+### [Unreleased]
+
+
 ## [0.5.15] 2025-05-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/ocsdk",
-  "version": "0.5.16-0",
+  "version": "0.5.16",
   "description": "Microsoft Omnichannel SDK",
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/ocsdk",
-  "version": "0.5.16",
+  "version": "0.5.17-0",
   "description": "Microsoft Omnichannel SDK",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
This pull request includes minor updates to prepare for a new release of the `@microsoft/ocsdk` package. The changes involve updating the version number and modifying the changelog to reflect the new release.

Release preparation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL5-R8): Added a new entry for version `0.5.15` with the release date and adjusted the formatting of the "Unreleased" section.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.5.16-0` to `0.5.17-0`.