### PR TITLE
Add backend call logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Added logging for backendElapsedTimeInMilliseconds
+
 ## [0.5.17] - 2025-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Added logging for backendElapsedTimeInMilliseconds
+- Added logging for httpRequestResponseTime
 
 ## [0.5.17] - 2025-06-24
 

--- a/src/Model/IOCSDKLogData.ts
+++ b/src/Model/IOCSDKLogData.ts
@@ -1,6 +1,7 @@
 export default interface IOCSDKLogData {
   RequestId: string;
   ElapsedTimeInMilliseconds?: number;
+  BackendElapsedTimeInMilliseconds?: number;
   Event?: string;
   Region?: string;
   TransactionId?: string;

--- a/src/Model/IOCSDKLogData.ts
+++ b/src/Model/IOCSDKLogData.ts
@@ -1,7 +1,7 @@
 export default interface IOCSDKLogData {
   RequestId: string;
   ElapsedTimeInMilliseconds?: number;
-  BackendElapsedTimeInMilliseconds?: number;
+  HttpRequestResponseTime?: number;
   Event?: string;
   Region?: string;
   TransactionId?: string;

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -640,6 +640,7 @@ export default class SDK implements ISDK {
 
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
+          return;
         }
         reject(error);
       }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -151,10 +151,10 @@ export default class SDK implements ISDK {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
       });
-      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data } = response;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSSUCCEEDED, "Get LCW FCS details succeeded", "", response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSSUCCEEDED, "Get LCW FCS details succeeded", "", response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
       return data;
     } catch (error) {
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -196,7 +196,7 @@ export default class SDK implements ISDK {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
       });
-      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data } = response;
 
@@ -208,7 +208,7 @@ export default class SDK implements ISDK {
       if (response.headers && response.headers["date"]) {
         data.headers["date"] = response.headers["date"];
       }
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGSUCCEEDED, "Get Chat config succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGSUCCEEDED, "Get Chat config succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
       return data;
     } catch (error) {
@@ -285,12 +285,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLWISTATUSSUCCEEDED, "Get LWI Details succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLWISTATUSSUCCEEDED, "Get LWI Details succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
 
       } catch (error) {
@@ -381,7 +381,7 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
@@ -402,7 +402,7 @@ export default class SDK implements ISDK {
           }
 
           data.requestId = requestId;
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTOKENSUCCEEDED, "Get Chat Token succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTOKENSUCCEEDED, "Get Chat Token succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
           resolve(data);
           return;
         }
@@ -456,14 +456,14 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         // Resolves only if it contains reconnectable chats response which only happens on status 200
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSUCCEEDED, "Get Reconnectable Chats Succeeded and old session returned", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSUCCEEDED, "Get Reconnectable Chats Succeeded and old session returned", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
           resolve(data);
           return;
         }
@@ -509,17 +509,17 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
           resolve(data);
           return;
         }
         // No data found so returning null
-        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
         resolve();
         return;
@@ -617,13 +617,13 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETAGENTAVAILABILITYSUCCEEDED, "Get agent availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETAGENTAVAILABILITYSUCCEEDED, "Get agent availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
           resolve(data);
         }
@@ -729,12 +729,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -820,7 +820,7 @@ export default class SDK implements ISDK {
     try {
       const backendTimer = Timer.TIMER();
       const response = await axiosInstance(options);
-      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data, headers } = response;
       this.setAuthCodeNonce(headers);
@@ -837,7 +837,7 @@ export default class SDK implements ISDK {
       }
 
       data.requestId = requestId;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.CREATESESSIONSUCCEEDED, "Create coversation call Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.CREATESESSIONSUCCEEDED, "Create coversation call Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
       return data;
     } catch (error) {
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -903,12 +903,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONCLOSESUCCEEDED, "Session Close succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONCLOSESUCCEEDED, "Session Close succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
         resolve();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -962,17 +962,17 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         if (response.data?.authChatExist === true) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDSUCCEEDED, "Validate Auth Chat Record succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDSUCCEEDED, "Validate Auth Chat Record succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
           resolve(response.data);
         } else {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record Failed. Record is not found or request is not authorized", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record Failed. Record is not found or request is not authorized", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
           reject(new Error("Validate Auth Chat Record Failed. Record is not found or request is not authorized"));
         }
@@ -1038,12 +1038,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SUBMITPOSTCHATSUCCEEDED, "Submit Post Chat succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SUBMITPOSTCHATSUCCEEDED, "Submit Post Chat succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 
         resolve();
 
@@ -1111,12 +1111,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1183,11 +1183,11 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
         
@@ -1249,12 +1249,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1304,10 +1304,10 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.FETCHDATAMASKINGSUCCEEDED, "Fetch Data Masking succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.FETCHDATAMASKINGSUCCEEDED, "Fetch Data Masking succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1366,12 +1366,12 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1419,9 +1419,9 @@ export default class SDK implements ISDK {
       try {
         const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
-        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDTYPINGINDICATORSUCCEEDED, "Send Typing Indicator Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDTYPINGINDICATORSUCCEEDED, "Send Typing Indicator Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1449,7 +1449,7 @@ export default class SDK implements ISDK {
    * @param error Error
    * @param data Data
    */
-  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any, requestHeaders?: any, backendElapsedTimeInMilliseconds?: number): void { // eslint-disable-line @typescript-eslint/no-explicit-any
+  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any, requestHeaders?: any, httpRequestResponseTime?: number): void { // eslint-disable-line @typescript-eslint/no-explicit-any
     if (!this.logger) {
       return;
     }
@@ -1504,7 +1504,7 @@ export default class SDK implements ISDK {
       RequestId: requestId,
       Region: response?.data.Region,
       ElapsedTimeInMilliseconds: elapsedTimeInMilliseconds,
-      BackendElapsedTimeInMilliseconds: backendElapsedTimeInMilliseconds,
+      HttpRequestResponseTime: httpRequestResponseTime,
       TransactionId: response?.headers[Constants.transactionid],
       RequestPath: requestPath,
       RequestMethod: method,

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -146,13 +146,15 @@ export default class SDK implements ISDK {
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
 
     try {
+      const backendTimer = Timer.TIMER();
       const response = await axiosInstance.get(url, {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
       });
+      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data } = response;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSSUCCEEDED, "Get LCW FCS details succeeded", "", response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSSUCCEEDED, "Get LCW FCS details succeeded", "", response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
       return data;
     } catch (error) {
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -189,10 +191,12 @@ export default class SDK implements ISDK {
     }
 
     try {
+      const backendTimer = Timer.TIMER();
       const response = await axiosInstance.get(url, {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
       });
+      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data } = response;
 
@@ -204,7 +208,7 @@ export default class SDK implements ISDK {
       if (response.headers && response.headers["date"]) {
         data.headers["date"] = response.headers["date"];
       }
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGSUCCEEDED, "Get Chat config succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGSUCCEEDED, "Get Chat config succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
       return data;
     } catch (error) {
@@ -279,12 +283,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLWISTATUSSUCCEEDED, "Get LWI Details succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLWISTATUSSUCCEEDED, "Get LWI Details succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve(data);
 
       } catch (error) {
@@ -373,7 +379,9 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
@@ -394,7 +402,7 @@ export default class SDK implements ISDK {
           }
 
           data.requestId = requestId;
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTOKENSUCCEEDED, "Get Chat Token succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTOKENSUCCEEDED, "Get Chat Token succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
           resolve(data);
           return;
         }
@@ -446,14 +454,16 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         // Resolves only if it contains reconnectable chats response which only happens on status 200
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSUCCEEDED, "Get Reconnectable Chats Succeeded and old session returned", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTABLECHATSSUCCEEDED, "Get Reconnectable Chats Succeeded and old session returned", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
           resolve(data);
           return;
         }
@@ -497,17 +507,19 @@ export default class SDK implements ISDK {
     const axiosInstance = axios.create();
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability succeeded", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
           resolve(data);
           return;
         }
         // No data found so returning null
-        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.WARN, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYSUCCEEDED, "Get Reconnect availability didn't send any valid data", optionalParams?.requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
         resolve();
         return;
@@ -603,13 +615,15 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         if (data) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETAGENTAVAILABILITYSUCCEEDED, "Get agent availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETAGENTAVAILABILITYSUCCEEDED, "Get agent availability succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
           resolve(data);
         }
@@ -713,12 +727,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -802,7 +818,9 @@ export default class SDK implements ISDK {
     };
 
     try {
+      const backendTimer = Timer.TIMER();
       const response = await axiosInstance(options);
+      const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data, headers } = response;
       this.setAuthCodeNonce(headers);
@@ -819,7 +837,7 @@ export default class SDK implements ISDK {
       }
 
       data.requestId = requestId;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.CREATESESSIONSUCCEEDED, "Create coversation call Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.CREATESESSIONSUCCEEDED, "Create coversation call Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
       return data;
     } catch (error) {
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -883,12 +901,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONCLOSESUCCEEDED, "Session Close succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONCLOSESUCCEEDED, "Session Close succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
         resolve();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -940,17 +960,19 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         if (response.data?.authChatExist === true) {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDSUCCEEDED, "Validate Auth Chat Record succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDSUCCEEDED, "Validate Auth Chat Record succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
           resolve(response.data);
         } else {
-          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record Failed. Record is not found or request is not authorized", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+          this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record Failed. Record is not found or request is not authorized", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
           reject(new Error("Validate Auth Chat Record Failed. Record is not found or request is not authorized"));
         }
@@ -1014,12 +1036,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SUBMITPOSTCHATSUCCEEDED, "Submit Post Chat succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SUBMITPOSTCHATSUCCEEDED, "Submit Post Chat succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
 
         resolve();
 
@@ -1085,12 +1109,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve(data);
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1155,11 +1181,13 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data, headers } = response;
         this.setAuthCodeNonce(headers);
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve(data);
       } catch (error) {
         
@@ -1219,12 +1247,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1272,10 +1302,12 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         const { data } = response;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.FETCHDATAMASKINGSUCCEEDED, "Fetch Data Masking succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.FETCHDATAMASKINGSUCCEEDED, "Fetch Data Masking succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve(data);
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1332,12 +1364,14 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const { headers } = response;
         this.setAuthCodeNonce(headers);
 
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1383,9 +1417,11 @@ export default class SDK implements ISDK {
 
     return new Promise(async (resolve, reject) => {
       try {
+        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
+        const backendElapsedTimeInMilliseconds = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDTYPINGINDICATORSUCCEEDED, "Send Typing Indicator Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDTYPINGINDICATORSUCCEEDED, "Send Typing Indicator Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, backendElapsedTimeInMilliseconds);
         resolve();
       } catch (error) {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1413,7 +1449,7 @@ export default class SDK implements ISDK {
    * @param error Error
    * @param data Data
    */
-  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any, requestHeaders?: any): void { // eslint-disable-line @typescript-eslint/no-explicit-any
+  private logWithLogger(logLevel: LogLevel, telemetryEventType: OCSDKTelemetryEvent, description: string, requestId?: string, response?: AxiosResponse<any>, elapsedTimeInMilliseconds?: number, requestPath?: string, method?: string, error?: unknown, requestPayload?: any, requestHeaders?: any, backendElapsedTimeInMilliseconds?: number): void { // eslint-disable-line @typescript-eslint/no-explicit-any
     if (!this.logger) {
       return;
     }
@@ -1468,6 +1504,7 @@ export default class SDK implements ISDK {
       RequestId: requestId,
       Region: response?.data.Region,
       ElapsedTimeInMilliseconds: elapsedTimeInMilliseconds,
+      BackendElapsedTimeInMilliseconds: backendElapsedTimeInMilliseconds,
       TransactionId: response?.headers[Constants.transactionid],
       RequestPath: requestPath,
       RequestMethod: method,

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -751,6 +751,7 @@ export default class SDK implements ISDK {
         
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
+          return;
         }
         reject(error);
       }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -159,7 +159,7 @@ export default class SDK implements ISDK {
     } catch (error) {
       const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSFAILED, "Get LCW FCS details failed", "", undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
+      this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETLCWFCSDETAILSFAILED, "Get LCW FCS details failed", "", undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
       throw error;
     }
   }
@@ -215,7 +215,7 @@ export default class SDK implements ISDK {
     } catch (error) {
       const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGFAILED, "Get Chat config failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
+      this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETCHATCONFIGFAILED, "Get Chat config failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
       return Promise.reject(error);
     }
   }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -145,8 +145,8 @@ export default class SDK implements ISDK {
     const requestHeaders = {};
     addOcUserAgentHeader(this.ocUserAgent, requestHeaders);
 
+    const backendTimer = Timer.TIMER();
     try {
-      const backendTimer = Timer.TIMER();
       const response = await axiosInstance.get(url, {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
@@ -157,8 +157,9 @@ export default class SDK implements ISDK {
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSSUCCEEDED, "Get LCW FCS details succeeded", "", response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
       return data;
     } catch (error) {
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSFAILED, "Get LCW FCS details failed", "", undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETLCWFCSDETAILSFAILED, "Get LCW FCS details failed", "", undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
       throw error;
     }
   }
@@ -190,8 +191,8 @@ export default class SDK implements ISDK {
       requestHeaders = { ...Constants.bypassCacheHeaders, ...requestHeaders };
     }
 
+    const backendTimer = Timer.TIMER();
     try {
-      const backendTimer = Timer.TIMER();
       const response = await axiosInstance.get(url, {
         headers: requestHeaders,
         timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getChatConfig
@@ -212,8 +213,9 @@ export default class SDK implements ISDK {
 
       return data;
     } catch (error) {
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGFAILED, "Get Chat config failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+      this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGFAILED, "Get Chat config failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
       return Promise.reject(error);
     }
   }
@@ -282,8 +284,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -294,8 +296,9 @@ export default class SDK implements ISDK {
         resolve(data);
 
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETLWISTATUSFAILED, "Get LWI Details failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETLWISTATUSFAILED, "Get LWI Details failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -378,8 +381,8 @@ export default class SDK implements ISDK {
     });
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -414,8 +417,9 @@ export default class SDK implements ISDK {
         }
 
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETCHATTOKENFAILED, "Get Chat Token failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETCHATTOKENFAILED, "Get Chat Token failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -453,8 +457,8 @@ export default class SDK implements ISDK {
     const axiosInstance = axios.create();
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -471,8 +475,9 @@ export default class SDK implements ISDK {
         resolve();
         return;
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTABLECHATSFAILED, "Get Reconnectable Chats failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTABLECHATSFAILED, "Get Reconnectable Chats failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -506,8 +511,8 @@ export default class SDK implements ISDK {
 
     const axiosInstance = axios.create();
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -524,8 +529,9 @@ export default class SDK implements ISDK {
         resolve();
         return;
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", optionalParams?.requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETRECONNECTAVAILABILITYFAILED, "Get Reconnect Availability failed", optionalParams?.requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -614,8 +620,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -628,8 +634,9 @@ export default class SDK implements ISDK {
           resolve(data);
         }
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETAGENTAVAILABILITYFAILED, "Get agent availability failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETAGENTAVAILABILITYFAILED, "Get agent availability failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
 
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
@@ -726,8 +733,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -737,8 +744,9 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SESSIONINITSUCCEEDED, "Session Init Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, data, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONINITFAILED, "Session Init failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONINITFAILED, "Session Init failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data, requestHeaders, httpRequestResponseTime);
         
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
@@ -817,8 +825,8 @@ export default class SDK implements ISDK {
       timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.sessionInit
     };
 
+    const backendTimer = Timer.TIMER();
     try {
-      const backendTimer = Timer.TIMER();
       const response = await axiosInstance(options);
       const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -840,8 +848,9 @@ export default class SDK implements ISDK {
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.CREATESESSIONSUCCEEDED, "Create coversation call Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
       return data;
     } catch (error) {
+      const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-      this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.CREATESESSIONFAILED, "Create conversation call failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data, requestHeaders);
+      this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.CREATESESSIONFAILED, "Create conversation call failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, data, requestHeaders, httpRequestResponseTime);
       
       if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
         throw new Error(this.HTTPTimeOutErrorMessage);
@@ -900,8 +909,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
@@ -913,8 +922,9 @@ export default class SDK implements ISDK {
         resolve();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONCLOSEFAILED, "Session close failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SESSIONCLOSEFAILED, "Session close failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (error.code === Constants.axiosTimeoutErrorCode) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -959,8 +969,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
@@ -979,9 +989,10 @@ export default class SDK implements ISDK {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
 
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.VALIDATEAUTHCHATRECORDFAILED, "Validate Auth Chat Record failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
 
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
@@ -1035,8 +1046,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
@@ -1048,8 +1059,9 @@ export default class SDK implements ISDK {
         resolve();
 
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SUBMITPOSTCHATFAILED, "Submit Post Chat Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SUBMITPOSTCHATFAILED, "Submit Post Chat Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -1108,8 +1120,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { data, headers } = response;
@@ -1119,8 +1131,9 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETSURVEYINVITELINKSUCCEEDED, "Get Survey Invite Link Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETSURVEYINVITELINKFAILED, "Get Survey Invite Link failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETSURVEYINVITELINKFAILED, "Get Survey Invite Link failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -1180,8 +1193,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1190,9 +1203,10 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATTRANSCRIPTSUCCEEDED, "Get Chat Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETCHATTRANSCRIPTFAILED, "Get Chat Transcript failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETCHATTRANSCRIPTFAILED, "Get Chat Transcript failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject(new Error(this.HTTPTimeOutErrorMessage));
 
@@ -1246,8 +1260,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
@@ -1257,8 +1271,9 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.EMAILTRANSCRIPTSUCCEEDED, "Email Transcript succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.EMAILTRANSCRIPTFAILED, "Email Transcript Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.EMAILTRANSCRIPTFAILED, "Email Transcript Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -1301,8 +1316,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
@@ -1310,8 +1325,9 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.FETCHDATAMASKINGSUCCEEDED, "Fetch Data Masking succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve(data);
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.FETCHDATAMASKINGFAILED, "Fetch Data Masking Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.FETCHDATAMASKINGFAILED, "Fetch Data Masking Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -1363,8 +1379,8 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const { headers } = response;
@@ -1374,8 +1390,9 @@ export default class SDK implements ISDK {
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTSUCCEEDED, "Secondary Channel Event Request Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTFAILED, "Secondary Channel Event Request Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SECONDARYCHANNELEVENTREQUESTFAILED, "Secondary Channel Event Request Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));
         }
@@ -1416,16 +1433,17 @@ export default class SDK implements ISDK {
     };
 
     return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
       try {
-        const backendTimer = Timer.TIMER();
         const response = await axiosInstance(options);
         const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDTYPINGINDICATORSUCCEEDED, "Send Typing Indicator Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
         resolve();
       } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
-        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SENDTYPINGINDICATORFAILED, "Send Typing Indicator Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders);
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SENDTYPINGINDICATORFAILED, "Send Typing Indicator Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
 
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject( new Error(this.HTTPTimeOutErrorMessage));

--- a/src/Utils/TelemetryHelper.ts
+++ b/src/Utils/TelemetryHelper.ts
@@ -8,7 +8,7 @@ export default class TelemetryHelper {
     const logData = {
       Description: description,
       ElapsedTimeInMilliseconds: customData.ElapsedTimeInMilliseconds,
-      BackendElapsedTimeInMilliseconds: customData.BackendElapsedTimeInMilliseconds,
+      HttpRequestResponseTime: customData.HttpRequestResponseTime,
       Event: telemetryEvent,
       ExceptionDetails: customData.ExceptionDetails,
       Region: customData.Region,

--- a/src/Utils/TelemetryHelper.ts
+++ b/src/Utils/TelemetryHelper.ts
@@ -8,6 +8,7 @@ export default class TelemetryHelper {
     const logData = {
       Description: description,
       ElapsedTimeInMilliseconds: customData.ElapsedTimeInMilliseconds,
+      BackendElapsedTimeInMilliseconds: customData.BackendElapsedTimeInMilliseconds,
       Event: telemetryEvent,
       ExceptionDetails: customData.ExceptionDetails,
       Region: customData.Region,


### PR DESCRIPTION
# **Thank you for your contribution. Before submitting this PR, please include:**

## Id of the task, bug, story or other reference
[Bug 5207085]: Add performance time meassure to backend calls from OCSDK and research on possible noise around GetchatConfig

### Description
The Omnichannel SDK contains 18 public methods that provide comprehensive functionality for interacting with Omnichannel chat services. While these methods currently log the SDK method execution time in the telemetry, discrepancies (by up to as much as 1 second) have been reported between server-side elapsed time and client-side recorded time.

## Solution Proposed
In addition to logging the method execution time, we may also log the backend response time to see if there are any significant deltas between the two within the ocsdk.

### Acceptance criteria
Within the MSFT internal DB, each ocsdkevent also contains a valid backendElapsedTimeInMilliseconds column.

## Test cases and evidence
Using the script uploaded here - [sendTypingIndicator](https://microsoft-my.sharepoint.com/:u:/p/samuelbishop/EWxNF8O2-D9IjPSOoUXQYTcBRC1uNuZxwYQI8QPsEtMDvA?e=sJKcJU)

Each API was invoked 10x. The console output is located here:
https://microsoft-my.sharepoint.com/:u:/p/samuelbishop/EfYrWB_61EFNvO6Rz3akrLQBDgAWz_aiSgFGr3ZOOqEEgQ?e=YM9wRx

[Data Explorer Link](https://dataexplorer.azure.com/clusters/kusto.aria.microsoft.com/databases/1574efd98545488983328fac0c9bcb59?query=H4sIAAAAAAAAA3WQT2vCQBDF7%2F0US04RknUTTTQBT7XQHIrFCoVewv4ZzdZkN90daw%2F98F2peCj0MjDzfm%2FmMbI%2FeQQXRx3i6Ovp9Bh6S7nTnA5aOuvtHqm0wzSaUMWRC%2B4hjtazsmg3g9Gy48ZA3973Ggy2L9woYb8Ca2WQ0Ktja2Wo8Blkf%2FdNzh04IK9aHQAbRVYrEoGoysVS8DQrKpHOMyZSIcoiFSznGa9KvuTz6GZ9uGxqzN62Oz0AEYBnAEPiEA4wTOKc5UXKFinLd1lVz7I6K2k1L94mlP7HzGpWUlYEZhLujM6%2Bg8Q%2FlxKycYdGJbfsyS%2BQkDV46fSI2pqEbOHjBB6fOXYB6PnoQV3sjXnSfa89SGuUT8hj%2BPeV3YIfrfFwwX4AXAcNfZABAAA%3D)

cluster("https://kusto.aria.microsoft.com/").database("D365_Omnichannel_Client_Sandbox").occhatsdk_ocsdkevents
| where WidgetId == "eb9678ba-159b-410b-bb65-b02a1a96a8a4"
| where EventInfo_Time between (datetime(2025-07-02T19:31:16.945Z)..datetime(2025-07-02T19:33:06.055Z))
| project EventInfo_Time, OrgId, WidgetId, Event, Description, RequestPath, ElapsedTimeInMilliseconds, HttpRequestResponseTime  

![image](https://github.com/user-attachments/assets/36d14b03-8bcd-45bc-8d9e-2bba6cc1a111)
Without any setup or extra arguments added to each API the results were the following:
10/10 successes for getLcwFcsDetails
10/10 successes for getChatConfig
0/10 successes for getLWIDetails
10/10 successes for getChatToken
0/10 successes for getReconnectableChats
10/10 successes for getReconnectAvailability
0/10 successes for getAgentAvailability
0/10 successes for sessionInit
0/10 successes for createConversation
0/10 successes for sessionClose
0/10 successes for validateAuthChatRecord
0/10 successes for submitPostChatResponse
0/10 successes for getSurveyInviteLink
0/10 successes for getChatTranscripts
0/10 successes for emailTranscript
10/10 successes for fetchDataMaskingInfo
0/10 successes for makeSecondaryChannelEventRequest
10/10 successes for sendTypingIndicator

All as expected given the setup, liveworkitemstate and configuration.

The learning is the following: based on preliminary testing there are not significant differences between OCSDK method execution time and backend response times. However, we can confirm after the telemetry has some time to bake in production.

### Sanity Tests
- [x] You have tested all changes in Popout mode
- [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
- [x] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.**_
