### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/download-artifact@v4.1.8


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/omnichannel-sdk/security/code-scanning/4](https://github.com/microsoft/omnichannel-sdk/security/code-scanning/4)

To fix the issue, add an explicit `permissions` block in the `publish` job to define the least privileges required for its operations. Based on the workflow tasks, this job primarily interacts with npm and does not require write access to repository contents. The recommended permissions are `contents: read`, ensuring the job can read repository files if needed, without allowing write access. Other permissions (e.g., `packages: write`) can be added if interacting with GitHub Packages is required, but they are not apparent in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
