### PR TITLE
fix header override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.5.21]
-
 ### Changed
+- Uptake [axios@1.2.0](https://www.npmjs.com/package/axios/v/1.2.0)
 
-- Uptake axios@^1.12.0
+### Fixed
+- Fixed `getPersistentChatHistory` method to make `requestId` a required parameter and ensure it is always provided by the caller.
+- Prevent mutation of default headers by creating a shallow copy before modification in `getPersistentChatHistory` method.
 
 ## [0.5.19] 2025-09-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/ocsdk",
-  "version": "0.5.21-0",
+  "version": "0.5.20-0",
   "description": "Microsoft Omnichannel SDK",
   "files": [
     "dist/**/*",

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1226,13 +1226,9 @@ export default class SDK implements ISDK {
    * @param requestId RequestId of the omnichannel session (Optional).
    * @param getPersistentChatHistoryOptionalParams Optional parameters for get persistent chat history.
    */
-  public async getPersistentChatHistory(requestId?: string, getPersistentChatHistoryOptionalParams: IGetPersistentChatHistoryOptionalParams = {}): Promise<object> {
+  public async getPersistentChatHistory(requestId: string, getPersistentChatHistoryOptionalParams: IGetPersistentChatHistoryOptionalParams = {}): Promise<object> {
     const timer = Timer.TIMER();
     this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETPERSISTENTCHATHISTORYSTARTED, "Get Persistent Chat History Started", requestId);
-    
-    if (!requestId) {
-      requestId = uuidv4();
-    }
 
     const { authenticatedUserToken, pageSize, pageToken } = getPersistentChatHistoryOptionalParams;
 
@@ -1250,7 +1246,7 @@ export default class SDK implements ISDK {
       waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.getPersistentChatHistory
     });
 
-    const requestHeaders: StringMap = Constants.defaultHeaders;
+    const requestHeaders: StringMap = { ...Constants.defaultHeaders };
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
 

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -814,23 +814,6 @@ describe("SDK unit tests", () => {
             });
         });
 
-        it("Should auto-generate requestId when not provided", (done) => {
-            const dataMockValid = { 
-                data: { conversations: [] }, 
-                headers: { "transaction-id": "tid" } 
-            };
-            const axiosInstMockValid = jasmine.createSpy("axiosInstance").and.returnValue(dataMockValid);
-            spyOn<any>(axios, "create").and.returnValue(axiosInstMockValid);
-            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
-            
-            const result = sdk.getPersistentChatHistory(undefined, getPersistentChatHistoryOptionalParams);
-            result.then(() => {
-                expect(uuidvSpy).toHaveBeenCalled();
-                expect(axiosInstMockValid).toHaveBeenCalled();
-                done();
-            });
-        });
-
         it("Should reject when authenticatedUserToken is missing", (done) => {
             const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
             


### PR DESCRIPTION
# **Thank you for your contribution. Before submitting this PR, please include:**

## Id of the task, bug, story or other reference

### Description
Include a description of the problem to be solved.
This pull request introduces several important fixes and improvements to the persistent chat history functionality, as well as a version update and dependency change. The main focus is on ensuring correct usage of parameters and preventing side effects in header management.

-### Reversing version, since it should be  updated only  via release process

### Persistent Chat History Improvements

* Made the `requestId` parameter required in the `getPersistentChatHistory` method to ensure it is always provided by the caller, improving reliability and eliminating unexpected behavior.
* Prevented mutation of the default headers by creating a shallow copy before modification in the `getPersistentChatHistory` method, avoiding unintended side effects across requests.

### Dependency and Version Updates

* Updated the `axios` dependency to version 1.2.0 for improved stability and compatibility.
* Reverted the package version from `0.5.21-0` to `0.5.20-0` in `package.json`.
## Solution Proposed
Detail what is the solution proposed, include links to design document if required or any other document required to support the solution.

### Acceptance criteria

Define what are the conditions to consider the PR has achieved the intended goal

## Test cases and evidence
Include what test cases were considered, any evidence of testing for future references, to identify any corner cases, etc.
<img width="699" height="467" alt="image" src="https://github.com/user-attachments/assets/22b2116f-28e9-4739-991e-7596e494e97f" />

<img width="1082" height="323" alt="image" src="https://github.com/user-attachments/assets/0cef64d8-4c89-4418-9137-4837f2a2deb0" />


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.**_
