### PR TITLE
ci: use npx npm@11.12.1 for publish to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -27,9 +27,6 @@ jobs:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Update package version from git
         if: ${{ github.ref == 'refs/heads/main' }}
         run: npx version-from-git --no-git-tag-version
@@ -58,4 +55,4 @@ jobs:
           fi
 
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
-        run: npm publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+        run: npx npm@11.12.1 publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix npm publish failing for prerelease versions by adding `--tag latest` to publish command
+- Use `npx npm@11.12.1` for publish step to fix OIDC trusted publishing (npm 10.9.7 can't do OIDC, and `npm install -g` crashes during self-upgrade)
 
 ## [0.5.21] - 2026-01-29
 


### PR DESCRIPTION
## Summary
- Use `npx npm@11.12.1 publish` instead of global npm for the publish step in npm-release.yml
- `npx` downloads npm 11.12.1 to a temp cache and runs it directly, avoiding the self-upgrade crash
- npm 10.9.7 (bundled with Node 22) can't do OIDC trusted publishing (E404)
- `npm install -g npm@latest` crashes during self-upgrade (`Cannot find module 'promise-retry'`)
- npm 11.12.1 is the last known working version (successful publish April 1)

## Test plan
- [ ] Merge and verify npm-release workflow succeeds on the resulting main push
- [ ] Confirm published package appears on npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)