### PR TITLE
feat: add getUnreadMessageCount and sendReadReceipt APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `getUnreadMessageCount` SDK method to fetch unread message count for authenticated users (auth-only, pre-session badge use case)
+- Added `sendReadReceipt` SDK method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS)
+- Added `GETUNREADMESSAGECOUNTSTARTED`, `GETUNREADMESSAGECOUNTSUCCEEDED`, `GETUNREADMESSAGECOUNTFAILED`, `SENDREADRECEIPTSTARTED`, `SENDREADRECEIPTSUCCEEDED`, `SENDREADRECEIPTFAILED` telemetry events in `OCSDKTelemetryEvent` enum
+- Added `getUnreadMessageCount` and `sendReadReceipt` to `ISDK` interface, `RequestTimeoutConfig` type, and `waitTimeBetweenRetriesConfigs`
+
 - Added `midConversationAuthenticateChat` SDK method to authenticate an ongoing unauthenticated chat session mid-conversation
 - Added `livechatconnector/auth/authenticateChat` endpoint in `OmnichannelEndpoints`
 - Added `MIDAUTHENTICATECHATSTARTED`, `MIDAUTHENTICATECHATSUCCEEDED`, `MIDAUTHENTICATECHATFAILED` telemetry events in `OCSDKTelemetryEvent` enum

--- a/src/Common/Enums.ts
+++ b/src/Common/Enums.ts
@@ -102,6 +102,12 @@ export enum OCSDKTelemetryEvent {
   MIDAUTHENTICATECHATSTARTED = "MidAuthenticateChatStarted",
   MIDAUTHENTICATECHATSUCCEEDED = "MidAuthenticateChatSucceeded",
   MIDAUTHENTICATECHATFAILED = "MidAuthenticateChatFailed",
+  GETUNREADMESSAGECOUNTSTARTED = "GetUnreadMessageCountStarted",
+  GETUNREADMESSAGECOUNTSUCCEEDED = "GetUnreadMessageCountSucceeded",
+  GETUNREADMESSAGECOUNTFAILED = "GetUnreadMessageCountFailed",
+  SENDREADRECEIPTSTARTED = "SendReadReceiptStarted",
+  SENDREADRECEIPTSUCCEEDED = "SendReadReceiptSucceeded",
+  SENDREADRECEIPTFAILED = "SendReadReceiptFailed",
 }
 
 export enum LiveChatVersion {

--- a/src/Common/RequestTimeoutConfig.ts
+++ b/src/Common/RequestTimeoutConfig.ts
@@ -19,4 +19,6 @@ export type RequestTimeoutConfig = {
     validateAuthChatRecordTimeout: number;
     getPersistentChatHistory: number;
     midConversationAuthenticateChat: number;
+    getUnreadMessageCount: number;
+    sendReadReceipt: number;
 }

--- a/src/Interfaces/ISDK.ts
+++ b/src/Interfaces/ISDK.ts
@@ -25,4 +25,6 @@ export default interface ISDK {
   getAgentAvailability(requestId: string, queueAvailabilityOptionalParams: IGetQueueAvailabilityOptionalParams): Promise<object>
   sendTypingIndicator(requestId: string, currentLiveChatVersion: number): Promise<void>;
   midConversationAuthenticateChat(requestId: string, authenticateChatParams: { chatId: string; authenticatedUserToken: string }): Promise<void>;
+  getUnreadMessageCount(authenticatedUserToken: string): Promise<object>;
+  sendReadReceipt(requestId: string, messageId: string, authenticatedUserToken: string): Promise<void>;
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -69,7 +69,9 @@ export default class SDK implements ISDK {
     sendTypingIndicator: 5000,
     validateAuthChatRecordTimeout: 15000,
     getPersistentChatHistory: 15000,
-    midConversationAuthenticateChat: 15000
+    midConversationAuthenticateChat: 15000,
+    getUnreadMessageCount: 15000,
+    sendReadReceipt: 5000
   };
 
   private static defaultConfiguration: ISDKConfiguration = {
@@ -1595,6 +1597,118 @@ export default class SDK implements ISDK {
         const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
         this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.MIDAUTHENTICATECHATFAILED, "Mid-Authenticate Chat Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
 
+        if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
+          reject(new Error(this.HTTPTimeOutErrorMessage));
+          return;
+        }
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Fetches unread message count for the authenticated user.
+   * Auth-only endpoint — does not require an active chat session.
+   * @param authenticatedUserToken Auth token for the user.
+   */
+  public async getUnreadMessageCount(authenticatedUserToken: string): Promise<object> {
+    const timer = Timer.TIMER();
+    const requestId = uuidv4();
+    this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETUNREADMESSAGECOUNTSTARTED, "Get Unread Message Count Started", requestId);
+
+    const requestPath = `/${OmnichannelEndpoints.LiveChatConnectorAuthPath}/${this.omnichannelConfiguration.orgId}/widgetapp/${this.omnichannelConfiguration.widgetId}/unreadmessages`;
+    const axiosInstance = axios.create();
+    axiosRetryHandler(axiosInstance, {
+      retries: this.configuration.maxRequestRetriesOnFailure,
+      waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.getUnreadMessageCount
+    });
+
+    const requestHeaders: StringMap = Constants.defaultHeaders;
+    requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
+    requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
+
+    this.addDefaultHeaders(requestId, requestHeaders);
+
+    const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
+    const method = "GET";
+    const options: AxiosRequestConfig = {
+      headers: requestHeaders,
+      method,
+      url,
+      timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.getUnreadMessageCount
+    };
+
+    return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
+      try {
+        const response = await axiosInstance(options);
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
+        const { data, headers } = response;
+        this.setAuthCodeNonce(headers);
+        const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETUNREADMESSAGECOUNTSUCCEEDED, "Get Unread Message Count Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
+        resolve(data);
+      } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
+        const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.GETUNREADMESSAGECOUNTFAILED, "Get Unread Message Count Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
+        if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
+          reject(new Error(this.HTTPTimeOutErrorMessage));
+          return;
+        }
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Sends a read receipt for a specific message in an authenticated conversation.
+   * Updates the unread message counter on the server and forwards the receipt to ACS.
+   * @param requestId RequestId (conversationThreadId) of the conversation.
+   * @param messageId The ACS message ID to mark as read.
+   * @param authenticatedUserToken Auth token for the user.
+   */
+  public async sendReadReceipt(requestId: string, messageId: string, authenticatedUserToken: string): Promise<void> {
+    const timer = Timer.TIMER();
+    this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDREADRECEIPTSTARTED, "Send Read Receipt Started", requestId);
+
+    const requestPath = `/${OmnichannelEndpoints.LiveChatConnectorAuthPath}/${this.omnichannelConfiguration.orgId}/widgetapp/${this.omnichannelConfiguration.widgetId}/conversations/${requestId}/readreceipt`;
+    const axiosInstance = axios.create();
+    axiosRetryHandler(axiosInstance, {
+      retries: this.configuration.maxRequestRetriesOnFailure,
+      waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.sendReadReceipt
+    });
+
+    const requestHeaders: StringMap = Constants.defaultHeaders;
+    requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
+    requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
+
+    this.addDefaultHeaders(requestId, requestHeaders);
+
+    const url = `${this.omnichannelConfiguration.orgUrl}${requestPath}`;
+    const method = "POST";
+    const options: AxiosRequestConfig = {
+      data: JSON.stringify({ messageId }),
+      headers: requestHeaders,
+      method,
+      url,
+      timeout: this.configuration.defaultRequestTimeout ?? this.configuration.requestTimeoutConfig.sendReadReceipt
+    };
+
+    return new Promise(async (resolve, reject) => {
+      const backendTimer = Timer.TIMER();
+      try {
+        const response = await axiosInstance(options);
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
+        const { headers } = response;
+        this.setAuthCodeNonce(headers);
+        const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
+        this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.SENDREADRECEIPTSUCCEEDED, "Send Read Receipt Succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
+        resolve();
+      } catch (error) {
+        const httpRequestResponseTime = backendTimer.milliSecondsElapsed;
+        const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
+        this.logWithLogger(LogLevel.ERROR, OCSDKTelemetryEvent.SENDREADRECEIPTFAILED, "Send Read Receipt Failed", requestId, undefined, elapsedTimeInMilliseconds, requestPath, method, error, undefined, requestHeaders, httpRequestResponseTime);
         if (isExpectedAxiosError(error, Constants.axiosTimeoutErrorCode)) {
           reject(new Error(this.HTTPTimeOutErrorMessage));
           return;

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1623,7 +1623,7 @@ export default class SDK implements ISDK {
       waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.getUnreadMessageCount
     });
 
-    const requestHeaders: StringMap = Constants.defaultHeaders;
+    const requestHeaders: StringMap = { ...Constants.defaultHeaders };
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
 
@@ -1679,7 +1679,7 @@ export default class SDK implements ISDK {
       waitTimeInMsBetweenRetries: this.configuration.waitTimeBetweenRetriesConfig.sendReadReceipt
     });
 
-    const requestHeaders: StringMap = Constants.defaultHeaders;
+    const requestHeaders: StringMap = { ...Constants.defaultHeaders };
     requestHeaders[OmnichannelHTTPHeaders.authenticatedUserToken] = authenticatedUserToken;
     requestHeaders[OmnichannelHTTPHeaders.authCodeNonce] = this.configuration.authCodeNonce;
 

--- a/src/Utils/waitTimeBetweenRetriesConfigs.ts
+++ b/src/Utils/waitTimeBetweenRetriesConfigs.ts
@@ -18,5 +18,7 @@ export const waitTimeBetweenRetriesConfigs : RequestTimeoutConfig =  {
     sendTypingIndicator: 1000,
     validateAuthChatRecordTimeout: 1000,
     getPersistentChatHistory: 1000,
-    midConversationAuthenticateChat: 1000
+    midConversationAuthenticateChat: 1000,
+    getUnreadMessageCount: 1000,
+    sendReadReceipt: 1000
   };

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -1316,4 +1316,169 @@ describe("SDK unit tests", () => {
             });
         });
     });
+
+    describe("Test getUnreadMessageCount method", () => {
+        const authenticatedUserToken = "validAuthToken";
+
+        it("Should use correct endpoint path", (done) => {
+            const dataMockSuccess = { data: { unreadMessageCount: 3 }, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.getUnreadMessageCount(authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.url).toContain(`/livechatconnector/auth/organization/${ochannelConfig.orgId}/widgetapp/${ochannelConfig.widgetId}/unreadmessages`);
+                done();
+            });
+        });
+
+        it("Should return promise with unread message data", (done) => {
+            const mockUnreadData = { unreadMessageCount: 3, mostRecentUnreadMessage: { id: "123", content: "Hello" } };
+            const dataMockValid = { data: mockUnreadData, headers: {} };
+            const axiosInstMockValid = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockValid));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockValid);
+            spyOn(ocsdkLogger, "log").and.callFake(() => { });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
+
+            const result = sdk.getUnreadMessageCount(authenticatedUserToken);
+            result.then((data) => {
+                expect(axiosInstMockValid).toHaveBeenCalled();
+                expect(data).toEqual(mockUnreadData);
+                expect(ocsdkLogger.log).toHaveBeenCalled();
+                done();
+            }).catch(() => {
+                fail("Promise should resolve");
+            });
+        });
+
+        it("Should use GET method", (done) => {
+            const dataMockSuccess = { data: { unreadMessageCount: 0 }, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.getUnreadMessageCount(authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.method).toEqual("GET");
+                done();
+            });
+        });
+
+        it("Should include authenticatedUserToken in request headers", (done) => {
+            const dataMockSuccess = { data: { unreadMessageCount: 0 }, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.getUnreadMessageCount(authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.headers["AuthenticatedUserToken"]).toEqual(authenticatedUserToken);
+                done();
+            });
+        });
+
+        it("Should reject when axiosInstance throws an error", (done) => {
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockWithError);
+            spyOn(ocsdkLogger, "log").and.callFake(() => { });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
+
+            const result = sdk.getUnreadMessageCount(authenticatedUserToken);
+            result.then(() => {
+                fail("Promise should reject");
+            }, () => {
+                expect(ocsdkLogger.log).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
+
+    describe("Test sendReadReceipt method", () => {
+        const authenticatedUserToken = "validAuthToken";
+        const messageId = "1777185788167";
+
+        it("Should use correct endpoint path", (done) => {
+            const dataMockSuccess = { data: {}, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.url).toContain(`/livechatconnector/auth/organization/${ochannelConfig.orgId}/widgetapp/${ochannelConfig.widgetId}/conversations/${requestId}/readreceipt`);
+                done();
+            });
+        });
+
+        it("Should return promise resolve", (done) => {
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                expect(axiosInstMock).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it("Should use POST method", (done) => {
+            const dataMockSuccess = { data: {}, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.method).toEqual("POST");
+                done();
+            });
+        });
+
+        it("Should include messageId in request body", (done) => {
+            const dataMockSuccess = { data: {}, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.data).toEqual(JSON.stringify({ messageId }));
+                done();
+            });
+        });
+
+        it("Should include authenticatedUserToken in request headers", (done) => {
+            const dataMockSuccess = { data: {}, headers: {} };
+            const axiosInstMockSuccess = jasmine.createSpy("axiosInstance").and.callFake(() => Promise.resolve(dataMockSuccess));
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockSuccess);
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                const callArgs = axiosInstMockSuccess.calls.mostRecent().args[0];
+                expect(callArgs.headers["AuthenticatedUserToken"]).toEqual(authenticatedUserToken);
+                done();
+            });
+        });
+
+        it("Should reject when axiosInstance throws an error", (done) => {
+            spyOn<any>(axios, "create").and.returnValue(axiosInstMockWithError);
+            spyOn(ocsdkLogger, "log").and.callFake(() => { });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration, undefined, ocsdkLogger);
+
+            const result = sdk.sendReadReceipt(requestId, messageId, authenticatedUserToken);
+            result.then(() => {
+                fail("Promise should reject");
+            }, () => {
+                expect(ocsdkLogger.log).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
 });

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -917,7 +917,7 @@ describe("SDK unit tests", () => {
             defaultOpt = {
                 authenticatedUserToken: "token",
                 initContext: {},
-                getContext: true,
+                getContext: false,
                 chatId: "chatId"
             };
             sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);


### PR DESCRIPTION
# **Thank you for your contribution. Before submitting this PR, please include:**

## Id of the task, bug, story or other reference
[User Story 6331091](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/6331091): [OCSDK] Add read receipt support

### Description

Today there is no way to convey to the agent that customer has read a message, and for customer to know how many unread messages from agent do they have.

## Solution Proposed

Add two new authenticated SDK methods for read receipt support:
- getUnreadMessageCount: GET call to fetch unread count per widget (auth-only)
- sendReadReceipt: POST call to mark messages as read via MRT

Includes telemetry events, timeout configs, interface updates, and tests.

### Acceptance criteria

Define what are the conditions to consider the PR has achieved the intended goal

## Test cases and evidence

Local testing and test cases.

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues
N/A

***Please provide justification if any of the validations has been skipped.**_
