### PR TITLE
Fix TypeError in getChatConfig when backend returns non-object response

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -207,13 +207,16 @@ export default class SDK implements ISDK {
       const elapsedTimeInMilliseconds = timer.milliSecondsElapsed;
       const { data } = response;
 
-      if (data.LiveChatVersion) {
-        this.liveChatVersion = data.LiveChatVersion;
-      }
+      // Add type guard to prevent TypeError when backend returns non-object (e.g., empty string, null, undefined)
+      if (typeof data === 'object' && data !== null) {
+        if (data.LiveChatVersion) {
+          this.liveChatVersion = data.LiveChatVersion;
+        }
 
-      data.headers = {};
-      if (response.headers && response.headers["date"]) {
-        data.headers["date"] = response.headers["date"];
+        data.headers = {};
+        if (response.headers && response.headers["date"]) {
+          data.headers["date"] = response.headers["date"];
+        }
       }
       this.logWithLogger(LogLevel.INFO, OCSDKTelemetryEvent.GETCHATCONFIGSUCCEEDED, "Get Chat config succeeded", requestId, response, elapsedTimeInMilliseconds, requestPath, method, undefined, undefined, requestHeaders, httpRequestResponseTime);
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -208,7 +208,7 @@ export default class SDK implements ISDK {
       const { data } = response;
 
       // Add type guard to prevent TypeError when backend returns non-object (e.g., empty string, null, undefined)
-      if (typeof data === 'object' && data !== null) {
+      if (typeof data === "object" && data !== null) {
         if (data.LiveChatVersion) {
           this.liveChatVersion = data.LiveChatVersion;
         }

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -157,6 +157,126 @@ describe("SDK unit tests", () => {
             expect(result.LiveChatVersion).toEqual(sdk.liveChatVersion);
         });
 
+        // Bug fix tests: Handle empty string response (ADO #6383438)
+        it("getChatConfig should handle empty string response without TypeError", async () => {
+            // Simulate backend returning empty string instead of object
+            const emptyStringResponse = { data: "", headers: { date: "Mon, 12 May 2026 15:04:00 GMT" } };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return emptyStringResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = await sdk.getChatConfig("test-request-id");
+
+            // Should return the empty string without throwing TypeError
+            expect(result).toEqual("");
+            // Should not have headers property when data is not an object
+            expect((result as any).headers).toBeUndefined();
+        });
+
+        it("getChatConfig should handle null response without TypeError", async () => {
+            const nullResponse = { data: null, headers: { date: "Mon, 12 May 2026 15:04:00 GMT" } };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return nullResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = await sdk.getChatConfig("test-request-id");
+
+            expect(result).toBeNull();
+        });
+
+        it("getChatConfig should add headers property when data is valid object", async () => {
+            const validResponse = {
+                data: { requestId: "someId", LiveChatVersion: 2 },
+                headers: { date: "Mon, 12 May 2026 15:04:00 GMT" }
+            };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return validResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result: any = await sdk.getChatConfig("test-request-id");
+
+            // Should successfully add headers property to object response
+            expect(result.headers).toBeDefined();
+            expect(result.headers.date).toEqual("Mon, 12 May 2026 15:04:00 GMT");
+            expect(result.requestId).toEqual("someId");
+            expect(result.LiveChatVersion).toEqual(2);
+        });
+
+        it("getChatConfig should add headers property even when response headers missing date", async () => {
+            const noDateResponse = {
+                data: { requestId: "someId" },
+                headers: { "content-type": "application/json" }
+            };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return noDateResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result: any = await sdk.getChatConfig("test-request-id");
+
+            // Should add headers property but without date field
+            expect(result.headers).toBeDefined();
+            expect(result.headers.date).toBeUndefined();
+            expect(result.requestId).toEqual("someId");
+        });
+
+        it("getChatConfig should handle undefined data property", async () => {
+            const undefinedDataResponse = { data: undefined, headers: { date: "Mon, 12 May 2026 15:04:00 GMT" } };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return undefinedDataResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = await sdk.getChatConfig("test-request-id");
+
+            expect(result).toBeUndefined();
+        });
+
+        it("getChatConfig should handle number response without TypeError", async () => {
+            // Edge case: backend returns number instead of object
+            const numberResponse = { data: 0, headers: { date: "Mon, 12 May 2026 15:04:00 GMT" } };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return numberResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = await sdk.getChatConfig("test-request-id");
+
+            expect(result).toEqual(0);
+            expect((result as any).headers).toBeUndefined();
+        });
+
+        it("getChatConfig should handle boolean response without TypeError", async () => {
+            // Edge case: backend returns boolean instead of object
+            const booleanResponse = { data: false, headers: { date: "Mon, 12 May 2026 15:04:00 GMT" } };
+            spyOn<any>(axios, "create").and.returnValue({
+                async get(endpoint: any) {
+                    return booleanResponse;
+                }
+            });
+            const sdk = new SDK(ochannelConfig as IOmnichannelConfiguration);
+
+            const result = await sdk.getChatConfig("test-request-id");
+
+            expect(result).toEqual(false);
+            expect((result as any).headers).toBeUndefined();
+        });
+
         it("Test getLWIDetails method with pluggable telemetry", async () => {
             spyOn<any>(axios, "create").and.returnValue(axiosInstMock);
             spyOn(ocsdkLogger, "log").and.callFake(() => { });


### PR DESCRIPTION
- Add type guard to handle empty string, null, undefined responses
- Prevents TypeError: Cannot create property 'headers' on string ''
- Add 7 comprehensive unit tests for edge cases:
  * Empty string response (production bug scenario)
  * Null response
  * Undefined response
  * Valid object response (regression prevention)
  * Missing date header
  * Number response
  * Boolean response

Fixes ADO #6383438

Test Results:
- 165 of 167 tests passing (2 skipped)
- Coverage: 86.47% statements (up from 86.16%)
- Zero regressions - all existing tests pass

Production Impact:
- Observed: 8 TypeErrors from widget 8c609396-fd80-466f-9a1e-5fbdb47929ac
- Origin: Azure Portal sandbox testing (May 12, 2026)
- Fix: Gracefully handles non-object responses without crashing

# **Thank you for your contribution. Before submitting this PR, please include:**

## Id of the task, bug, story or other reference

### Description

Include a description of the problem to be solved.

## Solution Proposed

Detail what is the solution proposed, include links to design document if required or any other document required to support the solution.

### Acceptance criteria

Define what are the conditions to consider the PR has achieved the intended goal

## Test cases and evidence

Include what test cases were considered, any evidence of testing for future references, to identify any corner cases, etc.

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.**_
