### PR TITLE
Automate official GitHub releases for v0.6.0

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -116,7 +116,7 @@ jobs:
             flag && /^## \[/ {flag=0}
             flag {print}
           ' CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
+          if ! grep -q '[^[:space:]]' RELEASE_NOTES.md; then
             echo "::warning::No CHANGELOG entry found for version $VERSION; falling back to auto-generated notes."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,6 +17,8 @@ jobs:
   publish:
     if: github.repository == 'microsoft/omnichannel-sdk'
     runs-on: ubuntu-latest
+    outputs:
+      release-tarball: ${{ steps.pack-release.outputs.filename }}
     steps:
       - name: Checking out for ${{ github.ref }}
         uses: actions/checkout@v4
@@ -37,6 +39,19 @@ jobs:
           echo "name=$(jq -r '.name' package.json)" >> "$GITHUB_OUTPUT"
           echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          EXPECTED_TAG="v${{ steps.read-package-json.outputs.version }}"
+          if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} does not match package version ${{ steps.read-package-json.outputs.version }}."
+            exit 1
+          fi
+          if [[ "${{ steps.read-package-json.outputs.version }}" == *-* ]]; then
+            echo "::error::Release tags cannot publish prerelease versions with the latest npm dist-tag."
+            exit 1
+          fi
+
       - name: Install packages
         run: npm install
 
@@ -54,5 +69,66 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Pack release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: pack-release
+        run: echo "filename=$(npm pack --json | jq -r '.[0].filename')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-tarball
+          path: ${{ steps.pack-release.outputs.filename }}
+          if-no-files-found: error
+
+      - name: Publish release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: npx npm@11.12.1 publish "${{ steps.pack-release.outputs.filename }}" --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: npx npm@11.12.1 publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+
+  github-release:
+    if: needs.publish.result == 'success' && github.repository == 'microsoft/omnichannel-sdk' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out for ${{ github.ref }}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download release tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-tarball
+
+      - name: Extract CHANGELOG section for ${{ github.ref_name }}
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+            flag && /^## \[/ {flag=0}
+            flag {print}
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::warning::No CHANGELOG entry found for version $VERSION; falling back to auto-generated notes."
+            echo "fallback=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fallback=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: ${{ steps.changelog.outputs.fallback == 'false' && 'RELEASE_NOTES.md' || '' }}
+          generate_release_notes: ${{ steps.changelog.outputs.fallback == 'true' }}
+          files: ${{ needs.publish.outputs.release-tarball }}
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Security
-
-- Updated Axios to `^1.19.0`, which requires patched `form-data` and `follow-redirects` versions without adding unused direct dependencies.
-- Removed the stale dev-only Lodash override; the regenerated lockfile resolves the patched version through normal transitive constraints.
-
-### Changed
-
-- Standardized local, pull-request, and release builds on Node.js 22 and declared Node.js `>=22.12.0` as the supported runtime.
-- Axios now installs proxy support for its Node.js HTTP adapter; the browser bundle remains unchanged.
+## [0.6.0] - 2026-08-12
 
 ### Added
 
@@ -20,20 +12,20 @@ All notable changes to this project will be documented in this file.
 - Added `sendReadReceipt` SDK method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS)
 - Added `GETUNREADMESSAGECOUNTSTARTED`, `GETUNREADMESSAGECOUNTSUCCEEDED`, `GETUNREADMESSAGECOUNTFAILED`, `SENDREADRECEIPTSTARTED`, `SENDREADRECEIPTSUCCEEDED`, `SENDREADRECEIPTFAILED` telemetry events in `OCSDKTelemetryEvent` enum
 - Added `getUnreadMessageCount` and `sendReadReceipt` to `ISDK` interface, `RequestTimeoutConfig` type, and `waitTimeBetweenRetriesConfigs`
-
 - Added `midConversationAuthenticateChat` SDK method to authenticate an ongoing unauthenticated chat session mid-conversation
 - Added `livechatconnector/auth/authenticateChat` endpoint in `OmnichannelEndpoints`
 - Added `MIDAUTHENTICATECHATSTARTED`, `MIDAUTHENTICATECHATSUCCEEDED`, `MIDAUTHENTICATECHATFAILED` telemetry events in `OCSDKTelemetryEvent` enum
 - Added `midConversationAuthenticateChat` to `ISDK` interface, `RequestTimeoutConfig` type, and `waitTimeBetweenRetriesConfigs`
 - Added retry support and `authCodeNonce` header handling for mid-conversation authentication
 - Updates `sessionId` from response headers after successful mid-conversation authentication
-
-### Added
-
 - Add `en-au` (Australian English) to `supportedLocales` list
 
 ### Changed
 
+- Added automatic GitHub Releases with changelog notes and the npm tarball for `v*` tags.
+- Documented that automatic `main` prereleases and official releases both use the npm `latest` dist-tag.
+- Standardized local, pull-request, and release builds on Node.js 22 and declared Node.js `>=22.12.0` as the supported runtime.
+- Axios now installs proxy support for its Node.js HTTP adapter; the browser bundle remains unchanged.
 - Add `github.repository` guard to release workflows to prevent them from running on forks
 - Switch npm publishing to GitHub Actions OIDC trusted publishing (no NPM_TOKEN needed)
 - Dev versions now auto-publish on push to main (e.g. `0.5.22-main.abc1234`)
@@ -43,6 +35,11 @@ All notable changes to this project will be documented in this file.
 
 - Fix npm publish failing for prerelease versions by adding `--tag latest` to publish command
 - Use `npx npm@11.12.1` for publish step to fix OIDC trusted publishing (npm 10.9.7 can't do OIDC, and `npm install -g` crashes during self-upgrade)
+
+### Security
+
+- Updated Axios to `^1.19.0`, which requires patched `form-data` and `follow-redirects` versions without adding unused direct dependencies.
+- Removed the stale dev-only Lodash override; the regenerated lockfile resolves the patched version through normal transitive constraints.
 
 ## [0.5.21] - 2026-01-29
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Omnichannel SDK
 
 [![npm version](https://badge.fury.io/js/%40microsoft%2Focsdk.svg)](https://badge.fury.io/js/%40microsoft%2Focsdk)
-![Release CI](https://github.com/microsoft/omnichannel-sdk/workflows/Release%20CI/badge.svg)
+[![npm Release](https://github.com/microsoft/omnichannel-sdk/actions/workflows/npm-release.yml/badge.svg)](https://github.com/microsoft/omnichannel-sdk/actions/workflows/npm-release.yml)
 
 This repo contains the source code for getting up and running with the Omnichannel SDK on the web using standard web technologies and on mobile using React Native.
 
@@ -9,7 +9,7 @@ This repo contains the source code for getting up and running with the Omnichann
 
 ## Prerequisites
 
-- [Node v12.13.0](https://nodejs.org/en/) (or equivalent)
+- [Node.js 22.12.0 or later](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/)
 
 ## Installation
@@ -266,11 +266,11 @@ These are the available config options with its default values for the SDK.
 }
 ```
 
-# Releasing
+## Releasing
 
-See [docs/RELEASING.md](docs/RELEASING.md) for how to publish new versions to npm.
+See [docs/RELEASING.md](docs/RELEASING.md) for development builds, official npm and GitHub releases, legacy artifacts, and hotfixes.
 
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,43 +20,70 @@ Every push to `main` automatically publishes a dev version to npm:
 
 The workflow intentionally moves `latest` to each `main` prerelease. An install without a version can receive a prerelease.
 
-### Release Versions (Manual — Tag Push)
+### Official Releases (Release PR and Tag)
 
-To publish release version `0.6.0`:
+Use an approved semantic version. In the examples below, replace `0.6.1` and `197` with the new version and pull-request number.
 
-1. **Make sure that `package.json` and `package-lock.json` contain `0.6.0`.**
+```bash
+VERSION=0.6.1
+PR_NUMBER=197
+```
 
-   These files already contain `0.6.0` for this release. If the files contain another version, run:
+1. **Create a release branch from current `upstream/main`.**
 
    ```bash
-   npm version 0.6.0 --no-git-tag-version
+   git fetch upstream
+   git checkout -b "release/v$VERSION" upstream/main
    ```
 
-2. **Update `CHANGELOG.md`.**
+2. **Set the version in `package.json` and `package-lock.json`.**
 
-   Move the release entries to `## [0.6.0] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above the release.
-
-3. **Open a pull request** with the version and changelog changes. Merge it after all required checks pass.
-
-4. **Update the local `main` branch**:
    ```bash
-   git checkout main
-   git pull --ff-only upstream main
+   npm version "$VERSION" --no-git-tag-version
    ```
 
-5. **Create and push the release tag**:
+3. **Finalize `CHANGELOG.md`.**
+
+   Move all release entries below `## [$VERSION] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above that heading.
+
+4. **Open a pull request.**
+
+   Include `package.json`, `package-lock.json`, and `CHANGELOG.md`. Merge the pull request only after all required checks pass.
+
+   The merge to `main` publishes a `VERSION-main.SHA` prerelease with the npm `latest` dist-tag. This publish is expected.
+
+5. **Get the pull-request merge commit.**
+
    ```bash
-   git tag v0.6.0
-   git push upstream v0.6.0
+   MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo microsoft/omnichannel-sdk --json mergeCommit --jq '.mergeCommit.oid')
+   test -n "$MERGE_SHA"
    ```
 
-   The tag must equal `v` plus the version in `package.json`.
+6. **Create an annotated tag on that merge commit.**
 
-6. **Wait for the `npm Release` workflow.**
+   ```bash
+   git fetch upstream --tags
+   git tag -a "v$VERSION" "$MERGE_SHA" -m "Release v$VERSION"
+   git push upstream "v$VERSION"
+   ```
 
-The workflow makes sure that the tag matches the package version. Then it builds and publishes the package with `--tag latest`.
+   The tag must equal `v` plus the version in `package.json`. The workflow rejects mismatched tags and prerelease tags.
 
-The workflow also adds a provenance attestation on npmjs.com. It creates GitHub Release `v0.6.0` with notes and the npm `.tgz` file.
+7. **Wait for the tag workflows.**
+
+Do not use **Run workflow** for an official release. The pushed tag starts the npm and legacy artifact workflows.
+
+The npm workflow publishes the package with `--tag latest`. Then it creates GitHub Release `v$VERSION` with notes and the published npm tarball.
+
+### GitHub Release Notes
+
+The workflow removes `v` from the tag. For example, it converts `v0.6.1` to `0.6.1`.
+
+It finds `## [0.6.1]` in `CHANGELOG.md`. It copies that section until the next `## [` version heading.
+
+The copied text becomes the GitHub Release body. If the matching section is empty or absent, GitHub generates notes from merged pull requests.
+
+The workflow packs the package once. It publishes that `.tgz` file to npm and attaches the same file to the GitHub Release.
 
 ### CDN Release
 
@@ -72,17 +99,17 @@ npm view @microsoft/ocsdk version
 npm view @microsoft/ocsdk dist-tags
 
 # Check the official version
-npm view @microsoft/ocsdk@0.6.0 version
+npm view "@microsoft/ocsdk@$VERSION" version
 
 # Check the GitHub Release and its asset
-gh release view v0.6.0 --repo microsoft/omnichannel-sdk
+gh release view "v$VERSION" --repo microsoft/omnichannel-sdk
 ```
 
 ### Tag Format
 
 | Tag pattern | What publishes | npm dist-tag |
 |-------------|---------------|--------------|
-| `v*` (e.g. `v0.6.0`) | Release version from `package.json` | `latest` |
+| `v*` (e.g. `v0.6.1`) | Release version from `package.json` | `latest` |
 | Push to `main` | Dev version `X.Y.Z-main.<sha>` | `latest` |
 
 ### Hotfix Versions

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,43 +9,54 @@ This package uses **GitHub Actions OIDC trusted publishing** — no npm tokens o
 Every push to `main` automatically publishes a dev version to npm:
 
 ```
-0.5.21-main.abc1234
+0.6.0-main.abc1234
        ^^^^^^^^^^^^
        branch + short commit SHA (via version-from-git)
 ```
 
-- **npm tag**: `main` (not `latest`)
-- **Install**: `npm install @microsoft/ocsdk@main`
+- **npm dist-tag**: `latest`
+- **Install**: Use the exact version from the workflow output, such as `npm install @microsoft/ocsdk@0.6.0-main.abc1234`
 - **Triggered by**: Any merge/push to the `main` branch
+
+The workflow intentionally moves `latest` to each `main` prerelease. An install without a version can receive a prerelease.
 
 ### Release Versions (Manual — Tag Push)
 
-To publish a release version (e.g. `0.5.22`):
+To publish release version `0.6.0`:
 
-1. **Update the version** in `package.json`:
+1. **Make sure that `package.json` and `package-lock.json` contain `0.6.0`.**
+
+   These files already contain `0.6.0` for this release. If the files contain another version, run:
+
    ```bash
-   # Edit package.json version field to the new version
+   npm version 0.6.0 --no-git-tag-version
    ```
 
-2. **Update the changelog** in `CHANGELOG.md`
+2. **Update `CHANGELOG.md`.**
 
-3. **Commit and push** to main:
+   Move the release entries to `## [0.6.0] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above the release.
+
+3. **Open a pull request** with the version and changelog changes. Merge it after all required checks pass.
+
+4. **Update the local `main` branch**:
    ```bash
-   git add package.json CHANGELOG.md
-   git commit -m "Bump version to 0.5.22"
-   git push
+   git checkout main
+   git pull --ff-only upstream main
    ```
 
-4. **Create and push a tag**:
+5. **Create and push the release tag**:
    ```bash
-   git tag v0.5.22
-   git push origin v0.5.22
+   git tag v0.6.0
+   git push upstream v0.6.0
    ```
 
-5. The `npm-release.yml` workflow will:
-   - Build the package (`npm run build:prod`)
-   - Publish to npm with `--tag latest`
-   - Include provenance attestation (visible on npmjs.com)
+   The tag must equal `v` plus the version in `package.json`.
+
+6. **Wait for the `npm Release` workflow.**
+
+The workflow makes sure that the tag matches the package version. Then it builds and publishes the package with `--tag latest`.
+
+The workflow also adds a provenance attestation on npmjs.com. It creates GitHub Release `v0.6.0` with notes and the npm `.tgz` file.
 
 ### CDN Release
 
@@ -54,22 +65,25 @@ The CDN release is handled separately by `release.yml` (triggered on push to mai
 ### Verifying a Publish
 
 ```bash
-# Check latest release version
+# Read the version selected by latest
 npm view @microsoft/ocsdk version
 
-# Check all dist-tags (latest + main)
+# Read all dist-tags
 npm view @microsoft/ocsdk dist-tags
 
-# Check a specific dev version
-npm view @microsoft/ocsdk@main version
+# Check the official version
+npm view @microsoft/ocsdk@0.6.0 version
+
+# Check the GitHub Release and its asset
+gh release view v0.6.0 --repo microsoft/omnichannel-sdk
 ```
 
 ### Tag Format
 
 | Tag pattern | What publishes | npm dist-tag |
 |-------------|---------------|--------------|
-| `v*` (e.g. `v0.5.22`) | Release version from `package.json` | `latest` |
-| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `main` |
+| `v*` (e.g. `v0.6.0`) | Release version from `package.json` | `latest` |
+| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `latest` |
 
 ### Hotfix Versions
 
@@ -99,6 +113,8 @@ For urgent fixes that need to ship against an older release (not `main`), use a 
    npm view @microsoft/ocsdk@0.5.20-hotfix.<name>.1
    ```
 
+Do not create a `v*` tag for a hotfix prerelease. The workflow rejects prerelease tags to protect the `latest` dist-tag.
+
 #### Hotfix Version Naming Convention
 
 ```
@@ -113,6 +129,8 @@ Example: `0.5.20-hotfix.enau.1`
 
 ### Important Notes
 
-- **Burned versions**: If a publish fails, that version number is consumed by npm. You must bump to the next version.
+- **Published versions**: npm does not permit a second publish of the same version. Use a new version after npm accepts a bad publish.
 - **Trusted publisher**: Configured on npmjs.com to trust `microsoft/omnichannel-sdk` → `npm-release.yml`. No npm tokens needed.
 - **Provenance**: All publishes include a signed provenance statement verifiable on npmjs.com.
+- **Release notes**: A matching changelog section supplies the GitHub Release notes. GitHub generates notes when the section is absent.
+- **Release asset**: Each GitHub Release contains the npm `.tgz` file from `npm pack`.


### PR DESCRIPTION
## Summary
- create a GitHub Release for each official `v*` tag after npm publishing succeeds
- publish and attach the same packed npm tarball
- validate that the tag matches `package.json` and reject prerelease tags
- document that automatic `main` prereleases intentionally use the npm `latest` dist-tag
- finalize the changelog for `0.6.0`

## Release flow
After this PR merges, create and push `v0.6.0` from the merged `main` commit. The npm workflow will publish `@microsoft/ocsdk@0.6.0`, then create GitHub Release `v0.6.0` with changelog notes and the `.tgz` asset. The legacy CDN workflow remains disabled.

## Validation
- `npm run build:prod`
- `npm test` — 165 tests passed, 2 skipped
- `npm run lint` — 0 errors, 1 existing warning
- `npm pack --dry-run`
- workflow YAML and changelog extraction checks